### PR TITLE
ci: JaCoCo + SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -30,3 +32,12 @@ jobs:
           name: JUnit Tests
           path: target/surefire-reports/*.xml
           reporter: java-junit
+
+      - name: Analyze with SonarCloud
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn sonar:sonar --batch-mode
+          -Dsonar.projectKey=kete1987_sportmonks
+          -Dsonar.organization=kete1987
+          -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn sonar:sonar --batch-mode
+          -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.projectKey=kete1987_sportmonks
           -Dsonar.organization=kete1987
           -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <maven.source.version>3.3.1</maven.source.version>
         <maven.javadoc.version>3.11.2</maven.javadoc.version>
         <central.publishing.version>0.7.0</central.publishing.version>
+        <jacoco.version>0.8.12</jacoco.version>
     </properties>
 
     <dependencies>
@@ -147,6 +148,26 @@
                         <id>attach-sources</id>
                         <goals>
                             <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <maven.javadoc.version>3.11.2</maven.javadoc.version>
         <central.publishing.version>0.7.0</central.publishing.version>
         <jacoco.version>0.8.12</jacoco.version>
+        <sonar.maven.plugin.version>4.0.0.4121</sonar.maven.plugin.version>
     </properties>
 
     <dependencies>
@@ -151,6 +152,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar.maven.plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
## Summary

- Añade JaCoCo para generar cobertura de código (reporte XML en fase `test`)
- Integra análisis SonarCloud en el flujo de CI
- Fija versión explícita del `sonar-maven-plugin` para evitar warnings
- Añade `fetch-depth: 0` en el checkout para que SonarCloud tenga historial git completo

## Test plan

- [x] CI pasa en verde (build + tests + SonarCloud)
- [x] El análisis aparece en https://sonarcloud.io/project/overview?id=kete1987_sportmonks con cobertura

🤖 Generated with [Claude Code](https://claude.com/claude-code)