### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kete1987/sportmonks/security/code-scanning/1](https://github.com/kete1987/sportmonks/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` so the workflow does not rely on repository/org defaults.

Best single fix without changing intended functionality:
- Add workflow-level `permissions` right after the `on:` section (before `jobs:`), so it applies consistently to all jobs unless overridden.
- Use least privilege needed by current steps:
  - `contents: read` (checkout/source access)
  - `checks: write` and `pull-requests: write` (needed by test reporter to publish results/annotations to checks/PRs)

This change is confined to `.github/workflows/ci.yml` and requires no imports, methods, or extra definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
