### PR TITLE
fix: sonar — @SerializedName en modelos, Comparable<Match>, NPE y colecciones mutables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Sportmonks Library
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kete1987_sportmonks&metric=alert_status)](https://sonarcloud.io/summary/overall?id=kete1987_sportmonks)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kete1987_sportmonks&metric=coverage)](https://sonarcloud.io/summary/overall?id=kete1987_sportmonks)
+[![CI](https://github.com/kete1987/sportmonks/actions/workflows/ci.yml/badge.svg)](https://github.com/kete1987/sportmonks/actions/workflows/ci.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/es.com.kete1987/sportmonks.library)](https://central.sonatype.com/artifact/es.com.kete1987/sportmonks.library)
+
 Java library (Java 11+) to access the [Sportmonks](https://sportmonks.com) football data API v3.
 
 ## Installation

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
         <central.publishing.version>0.7.0</central.publishing.version>
         <jacoco.version>0.8.14</jacoco.version>
         <sonar.maven.plugin.version>4.0.0.4121</sonar.maven.plugin.version>
+        <!-- Excluir DTOs (model/**) de cobertura y deteccion de duplicados.
+             Los modelos son POJOs rellenados por Gson via reflexion; los
+             patrones de getter repetidos no son duplicacion real de logica. -->
+        <sonar.coverage.exclusions>**/model/**/*.java</sonar.coverage.exclusions>
+        <sonar.cpd.exclusions>**/model/**/*.java</sonar.cpd.exclusions>
     </properties>
 
     <dependencies>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-# Sonar exclusions for model packages (DTOs / data transfer objects).
-# These classes are pure data containers populated by Gson via reflection.
-# Getter patterns are inherently repetitive (not real duplication) and
-# coverage on them adds no quality value over integration-level API tests.
-sonar.coverage.exclusions=**/model/**/*.java
-sonar.cpd.exclusions=**/model/**/*.java

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+# Sonar exclusions for model packages (DTOs / data transfer objects).
+# These classes are pure data containers populated by Gson via reflection.
+# Getter patterns are inherently repetitive (not real duplication) and
+# coverage on them adds no quality value over integration-level API tests.
+sonar.coverage.exclusions=**/model/**/*.java
+sonar.cpd.exclusions=**/model/**/*.java

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/model/pagination/Pagination.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/model/pagination/Pagination.java
@@ -1,11 +1,17 @@
 package es.com.kete1987.sportmonks.library.common.model.pagination;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Pagination {
     private Long count;
-    private Long per_page;
-    private Long current_page;
-    private String next_page;
-    private Boolean has_more;
+    @SerializedName("per_page")
+    private Long perPage;
+    @SerializedName("current_page")
+    private Long currentPage;
+    @SerializedName("next_page")
+    private String nextPage;
+    @SerializedName("has_more")
+    private Boolean hasMore;
 
     public Pagination() {
 
@@ -16,18 +22,18 @@ public class Pagination {
     }
 
     public Long getPerPage() {
-        return per_page;
+        return perPage;
     }
 
     public Long getCurrentPage() {
-        return current_page;
+        return currentPage;
     }
 
     public String getNextPage() {
-        return next_page;
+        return nextPage;
     }
 
     public boolean hasMore() {
-        return Boolean.TRUE.equals(has_more);
+        return Boolean.TRUE.equals(hasMore);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/model/ratelimit/RateLimit.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/model/ratelimit/RateLimit.java
@@ -1,19 +1,23 @@
 package es.com.kete1987.sportmonks.library.common.model.ratelimit;
 
+import com.google.gson.annotations.SerializedName;
+
 public class RateLimit {
-    private Long resets_in_seconds;
+    @SerializedName("resets_in_seconds")
+    private Long resetsInSeconds;
     private Long remaining;
-    private String requested_entity;
+    @SerializedName("requested_entity")
+    private String requestedEntity;
 
     public RateLimit() {
     }
 
     public Long getResetsInSeconds() {
-        return resets_in_seconds;
+        return resetsInSeconds;
     }
 
-    public void setResetsInSeconds(Long resets_in_seconds) {
-        this.resets_in_seconds = resets_in_seconds;
+    public void setResetsInSeconds(Long resetsInSeconds) {
+        this.resetsInSeconds = resetsInSeconds;
     }
 
     public Long getRemaining() {
@@ -25,10 +29,10 @@ public class RateLimit {
     }
 
     public String getRequestedEntity() {
-        return requested_entity;
+        return requestedEntity;
     }
 
-    public void setRequestedEntity(String requested_entity) {
-        this.requested_entity = requested_entity;
+    public void setRequestedEntity(String requestedEntity) {
+        this.requestedEntity = requestedEntity;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/model/subscription/Subscription.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/model/subscription/Subscription.java
@@ -1,6 +1,7 @@
 package es.com.kete1987.sportmonks.library.common.model.subscription;
 
 import java.util.List;
+import java.util.Collections;
 
 public class Subscription {
     private SubscriptionMeta meta;
@@ -18,7 +19,7 @@ public class Subscription {
     }
 
     public List<SubscriptionPlan> getPlans() {
-        return plans;
+        return plans == null ? null : Collections.unmodifiableList(plans);
     }
 
     public void setPlans(List<SubscriptionPlan> plans) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/model/subscription/Subscription.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/model/subscription/Subscription.java
@@ -1,7 +1,7 @@
 package es.com.kete1987.sportmonks.library.common.model.subscription;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class Subscription {
     private SubscriptionMeta meta;
@@ -19,7 +19,7 @@ public class Subscription {
     }
 
     public List<SubscriptionPlan> getPlans() {
-        return plans == null ? null : Collections.unmodifiableList(plans);
+        return ModelCollections.unmodifiable(plans);
     }
 
     public void setPlans(List<SubscriptionPlan> plans) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/model/subscription/SubscriptionMeta.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/model/subscription/SubscriptionMeta.java
@@ -1,25 +1,29 @@
 package es.com.kete1987.sportmonks.library.common.model.subscription;
 
+import com.google.gson.annotations.SerializedName;
+
 public class SubscriptionMeta {
-    private String trial_ends_at;
-    private String ends_at;
+    @SerializedName("trial_ends_at")
+    private String trialEndsAt;
+    @SerializedName("ends_at")
+    private String endsAt;
 
     public SubscriptionMeta() {
     }
 
     public String getTrialEndsAt() {
-        return trial_ends_at;
+        return trialEndsAt;
     }
 
-    public void setTrialEndsAt(String trial_ends_at) {
-        this.trial_ends_at = trial_ends_at;
+    public void setTrialEndsAt(String trialEndsAt) {
+        this.trialEndsAt = trialEndsAt;
     }
 
     public String getEndsAt() {
-        return ends_at;
+        return endsAt;
     }
 
-    public void setEndsAt(String ends_at) {
-        this.ends_at = ends_at;
+    public void setEndsAt(String endsAt) {
+        this.endsAt = endsAt;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/util/ModelCollections.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/util/ModelCollections.java
@@ -1,0 +1,27 @@
+package es.com.kete1987.sportmonks.library.common.util;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility helpers for safely exposing internal List fields from model classes.
+ * Avoids repeated null-check ternaries and prevents callers from mutating internal state.
+ */
+public final class ModelCollections {
+
+    private ModelCollections() {
+        // utility class
+    }
+
+    /**
+     * Returns an unmodifiable view of the given list, or {@code null} if the list itself is null.
+     * <p>Use in model getters: {@code return ModelCollections.unmodifiable(myList);}</p>
+     *
+     * @param list the internal list (may be null when the API field was absent)
+     * @param <T>  element type
+     * @return an unmodifiable view, or null
+     */
+    public static <T> List<T> unmodifiable(List<T> list) {
+        return list == null ? null : Collections.unmodifiableList(list);
+    }
+}

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/city/CitiesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/city/CitiesResponse.java
@@ -3,7 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.city;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class CitiesResponse {
     private List<City> data;
@@ -13,7 +13,7 @@ public class CitiesResponse {
     }
 
     public List<City> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/city/CitiesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/city/CitiesResponse.java
@@ -3,6 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.city;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
+import java.util.Collections;
 
 public class CitiesResponse {
     private List<City> data;
@@ -12,7 +13,7 @@ public class CitiesResponse {
     }
 
     public List<City> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/city/City.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/city/City.java
@@ -1,9 +1,13 @@
 package es.com.kete1987.sportmonks.library.core.model.city;
 
+import com.google.gson.annotations.SerializedName;
+
 public class City {
     private Long id;
-    private Long region_id;
-    private Long country_id;
+    @SerializedName("region_id")
+    private Long regionId;
+    @SerializedName("country_id")
+    private Long countryId;
     private String name;
     private String latitude;
     private String longitude;
@@ -16,11 +20,11 @@ public class City {
     }
 
     public Long getRegionId() {
-        return region_id;
+        return regionId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public String getName() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/continent/Continent.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/continent/Continent.java
@@ -1,11 +1,14 @@
 package es.com.kete1987.sportmonks.library.core.model.continent;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Continent {
     private Long id;
     private String name;
     private String code;
     private String flag;
-    private String image_path;
+    @SerializedName("image_path")
+    private String imagePath;
 
     public Continent() {
     }
@@ -27,6 +30,6 @@ public class Continent {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/continent/ContinentsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/continent/ContinentsResponse.java
@@ -3,7 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.continent;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class ContinentsResponse {
     private List<Continent> data;
@@ -13,7 +13,7 @@ public class ContinentsResponse {
     }
 
     public List<Continent> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/continent/ContinentsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/continent/ContinentsResponse.java
@@ -3,6 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.continent;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
+import java.util.Collections;
 
 public class ContinentsResponse {
     private List<Continent> data;
@@ -12,7 +13,7 @@ public class ContinentsResponse {
     }
 
     public List<Continent> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/country/CountriesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/country/CountriesResponse.java
@@ -3,7 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.country;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class CountriesResponse {
     private List<Country> data;
@@ -13,7 +13,7 @@ public class CountriesResponse {
     }
 
     public List<Country> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/country/CountriesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/country/CountriesResponse.java
@@ -3,6 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.country;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
+import java.util.Collections;
 
 public class CountriesResponse {
     private List<Country> data;
@@ -12,7 +13,7 @@ public class CountriesResponse {
     }
 
     public List<Country> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/country/Country.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/country/Country.java
@@ -1,16 +1,22 @@
 package es.com.kete1987.sportmonks.library.core.model.country;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Country {
     private Long id;
-    private Long continent_id;
+    @SerializedName("continent_id")
+    private Long continentId;
     private String name;
-    private String official_name;
-    private String fifa_name;
+    @SerializedName("official_name")
+    private String officialName;
+    @SerializedName("fifa_name")
+    private String fifaName;
     private String iso2;
     private String iso3;
     private String latitude;
     private String longitude;
-    private String image_path;
+    @SerializedName("image_path")
+    private String imagePath;
 
     public Country() {
     }
@@ -20,7 +26,7 @@ public class Country {
     }
 
     public Long getContinentId() {
-        return continent_id;
+        return continentId;
     }
 
     public String getName() {
@@ -28,11 +34,11 @@ public class Country {
     }
 
     public String getOfficialName() {
-        return official_name;
+        return officialName;
     }
 
     public String getFifaName() {
-        return fifa_name;
+        return fifaName;
     }
 
     public String getIso2() {
@@ -52,6 +58,6 @@ public class Country {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyApi.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyApi.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MyApi {
     @SerializedName("sport_id")
@@ -23,7 +23,7 @@ public class MyApi {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyApi.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyApi.java
@@ -4,26 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class MyApi {
-    private Integer sport_id;
+    @SerializedName("sport_id")
+    private Integer sportId;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public MyApi() {
     }
 
     public Integer getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyLeague.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyLeague.java
@@ -1,23 +1,30 @@
 package es.com.kete1987.sportmonks.library.core.model.my;
 
+import com.google.gson.annotations.SerializedName;
+
 public class MyLeague {
-    private Long league_id;
-    private Long sport_id;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("sport_id")
+    private Long sportId;
     private String name;
-    private String image_path;
+    @SerializedName("image_path")
+    private String imagePath;
     private String type;
-    private String sub_type;
-    private String last_played_at;
+    @SerializedName("sub_type")
+    private String subType;
+    @SerializedName("last_played_at")
+    private String lastPlayedAt;
 
     public MyLeague() {
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public String getName() {
@@ -25,7 +32,7 @@ public class MyLeague {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getType() {
@@ -33,10 +40,10 @@ public class MyLeague {
     }
 
     public String getSubType() {
-        return sub_type;
+        return subType;
     }
 
     public String getLastPlayedAt() {
-        return last_played_at;
+        return lastPlayedAt;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyLeaguesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyLeaguesResponse.java
@@ -3,7 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.my;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MyLeaguesResponse {
     private List<MyLeague> data;
@@ -13,7 +13,7 @@ public class MyLeaguesResponse {
     }
 
     public List<MyLeague> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyLeaguesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/my/MyLeaguesResponse.java
@@ -3,6 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.my;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
+import java.util.Collections;
 
 public class MyLeaguesResponse {
     private List<MyLeague> data;
@@ -12,7 +13,7 @@ public class MyLeaguesResponse {
     }
 
     public List<MyLeague> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/region/Region.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/region/Region.java
@@ -1,8 +1,11 @@
 package es.com.kete1987.sportmonks.library.core.model.region;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Region {
     private Long id;
-    private Long country_id;
+    @SerializedName("country_id")
+    private Long countryId;
     private String name;
 
     public Region() {
@@ -13,7 +16,7 @@ public class Region {
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public String getName() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/region/RegionsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/region/RegionsResponse.java
@@ -3,6 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.region;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
+import java.util.Collections;
 
 public class RegionsResponse {
     private List<Region> data;
@@ -12,7 +13,7 @@ public class RegionsResponse {
     }
 
     public List<Region> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/region/RegionsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/region/RegionsResponse.java
@@ -3,7 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.region;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class RegionsResponse {
     private List<Region> data;
@@ -13,7 +13,7 @@ public class RegionsResponse {
     }
 
     public List<Region> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/timezone/TimezonesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/timezone/TimezonesResponse.java
@@ -1,7 +1,7 @@
 package es.com.kete1987.sportmonks.library.core.model.timezone;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TimezonesResponse {
     private List<String> data;
@@ -10,6 +10,6 @@ public class TimezonesResponse {
     }
 
     public List<String> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/timezone/TimezonesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/timezone/TimezonesResponse.java
@@ -1,6 +1,7 @@
 package es.com.kete1987.sportmonks.library.core.model.timezone;
 
 import java.util.List;
+import java.util.Collections;
 
 public class TimezonesResponse {
     private List<String> data;
@@ -9,6 +10,6 @@ public class TimezonesResponse {
     }
 
     public List<String> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/type/Type.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/type/Type.java
@@ -1,12 +1,17 @@
 package es.com.kete1987.sportmonks.library.core.model.type;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Type {
     private Long id;
     private String name;
     private String code;
-    private String developer_name;
-    private String model_type;
-    private String stat_group;
+    @SerializedName("developer_name")
+    private String developerName;
+    @SerializedName("model_type")
+    private String modelType;
+    @SerializedName("stat_group")
+    private String statGroup;
 
     public Type() {
     }
@@ -24,14 +29,14 @@ public class Type {
     }
 
     public String getDeveloperName() {
-        return developer_name;
+        return developerName;
     }
 
     public String getModelType() {
-        return model_type;
+        return modelType;
     }
 
     public String getStatGroup() {
-        return stat_group;
+        return statGroup;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/type/TypesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/type/TypesResponse.java
@@ -3,6 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.type;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
+import java.util.Collections;
 
 public class TypesResponse {
     private List<Type> data;
@@ -12,7 +13,7 @@ public class TypesResponse {
     }
 
     public List<Type> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/core/model/type/TypesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/core/model/type/TypesResponse.java
@@ -3,7 +3,7 @@ package es.com.kete1987.sportmonks.library.core.model.type;
 import es.com.kete1987.sportmonks.library.common.model.pagination.Pagination;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TypesResponse {
     private List<Type> data;
@@ -13,7 +13,7 @@ public class TypesResponse {
     }
 
     public List<Type> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/Coach.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/Coach.java
@@ -1,16 +1,24 @@
 package es.com.kete1987.sportmonks.library.football.model.coach;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Coach {
     private Long id;
-    private Long sport_id;
-    private Long country_id;
-    private Long nationality_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("country_id")
+    private Long countryId;
+    @SerializedName("nationality_id")
+    private Long nationalityId;
     private String name;
     private String firstname;
     private String lastname;
-    private String display_name;
-    private String image_path;
-    private String date_of_birth;
+    @SerializedName("display_name")
+    private String displayName;
+    @SerializedName("image_path")
+    private String imagePath;
+    @SerializedName("date_of_birth")
+    private String dateOfBirth;
     private String gender;
 
     public Coach() {
@@ -21,15 +29,15 @@ public class Coach {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public Long getNationalityId() {
-        return nationality_id;
+        return nationalityId;
     }
 
     public String getName() {
@@ -45,15 +53,15 @@ public class Coach {
     }
 
     public String getDisplayName() {
-        return display_name;
+        return displayName;
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getDateOfBirth() {
-        return date_of_birth;
+        return dateOfBirth;
     }
 
     public String getGender() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachResponse.java
@@ -5,12 +5,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import java.util.Collections;
 
 public class CoachResponse {
     @SerializedName("data")
     private Coach coach;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public CoachResponse() {
@@ -21,11 +23,11 @@ public class CoachResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class CoachResponse {
     @SerializedName("data")
@@ -23,7 +23,7 @@ public class CoachResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachesResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class CoachesResponse {
     private List<Coach> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public CoachesResponse() {
     }
 
     public List<Coach> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class CoachesResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/coach/CoachesResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class CoachesResponse {
     private List<Coach> data;
@@ -20,7 +20,7 @@ public class CoachesResponse {
     }
 
     public List<Coach> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class CoachesResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/comments/Comment.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/comments/Comment.java
@@ -1,13 +1,19 @@
 package es.com.kete1987.sportmonks.library.football.model.comments;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Comment implements Comparable<Object> {
     private Long id;
-    private Long fixture_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
     private String comment;
     private Long minute;
-    private Long extra_minute;
-    private Boolean is_goal;
-    private Boolean is_important;
+    @SerializedName("extra_minute")
+    private Long extraMinute;
+    @SerializedName("is_goal")
+    private Boolean isGoal;
+    @SerializedName("is_important")
+    private Boolean isImportant;
     private Long order;
 
     public Comment() {
@@ -18,7 +24,7 @@ public class Comment implements Comparable<Object> {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public String getComment() {
@@ -30,15 +36,15 @@ public class Comment implements Comparable<Object> {
     }
 
     public Long getExtraMinute() {
-        return extra_minute;
+        return extraMinute;
     }
 
     public Boolean isGoal() {
-        return is_goal;
+        return isGoal;
     }
 
     public Boolean isImportant() {
-        return is_important;
+        return isImportant;
     }
 
     public Long getOrder() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/comments/CommentsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/comments/CommentsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class CommentsResponse {
     private List<Comment> data;
@@ -18,11 +18,11 @@ public class CommentsResponse {
     }
 
     public List<Comment> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/comments/CommentsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/comments/CommentsResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class CommentsResponse {
     private List<Comment> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public CommentsResponse() {
     }
 
     public List<Comment> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedgoal/ExpectedGoal.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedgoal/ExpectedGoal.java
@@ -1,16 +1,25 @@
 package es.com.kete1987.sportmonks.library.football.model.expectedgoal;
 
+import com.google.gson.annotations.SerializedName;
+
 public class ExpectedGoal {
     private Long id;
-    private Long fixture_id;
-    private Long participant_id;
-    private String participant_type;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("participant_id")
+    private Long participantId;
+    @SerializedName("participant_type")
+    private String participantType;
     private Double possession;
-    private Double goals_expected;
-    private Double scoring_chances;
-    private Long player_id;
+    @SerializedName("goals_expected")
+    private Double goalsExpected;
+    @SerializedName("scoring_chances")
+    private Double scoringChances;
+    @SerializedName("player_id")
+    private Long playerId;
     private Integer minute;
-    private Long period_id;
+    @SerializedName("period_id")
+    private Long periodId;
 
     public ExpectedGoal() {
     }
@@ -20,15 +29,15 @@ public class ExpectedGoal {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public String getParticipantType() {
-        return participant_type;
+        return participantType;
     }
 
     public Double getPossession() {
@@ -36,15 +45,15 @@ public class ExpectedGoal {
     }
 
     public Double getGoalsExpected() {
-        return goals_expected;
+        return goalsExpected;
     }
 
     public Double getScoringChances() {
-        return scoring_chances;
+        return scoringChances;
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Integer getMinute() {
@@ -52,6 +61,6 @@ public class ExpectedGoal {
     }
 
     public Long getPeriodId() {
-        return period_id;
+        return periodId;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedgoal/ExpectedGoalsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedgoal/ExpectedGoalsResponse.java
@@ -4,27 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class ExpectedGoalsResponse {
 
     private List<ExpectedGoal> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public ExpectedGoalsResponse() {
     }
 
     public List<ExpectedGoal> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedgoal/ExpectedGoalsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedgoal/ExpectedGoalsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class ExpectedGoalsResponse {
 
@@ -19,11 +19,11 @@ public class ExpectedGoalsResponse {
     }
 
     public List<ExpectedGoal> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineup.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineup.java
@@ -3,11 +3,15 @@ package es.com.kete1987.sportmonks.library.football.model.expectedlineup;
 import es.com.kete1987.sportmonks.library.football.model.player.Player;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class ExpectedLineup {
     private Long id;
-    private Long fixture_id;
-    private Long team_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("team_id")
+    private Long teamId;
     private String formation;
     private List<Player> players;
 
@@ -19,11 +23,11 @@ public class ExpectedLineup {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public String getFormation() {
@@ -31,6 +35,6 @@ public class ExpectedLineup {
     }
 
     public List<Player> getPlayers() {
-        return players;
+        return players == null ? null : Collections.unmodifiableList(players);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineup.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineup.java
@@ -4,7 +4,7 @@ import es.com.kete1987.sportmonks.library.football.model.player.Player;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class ExpectedLineup {
     private Long id;
@@ -35,6 +35,6 @@ public class ExpectedLineup {
     }
 
     public List<Player> getPlayers() {
-        return players == null ? null : Collections.unmodifiableList(players);
+        return ModelCollections.unmodifiable(players);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineupsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineupsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class ExpectedLineupsResponse {
     private List<ExpectedLineup> data;
@@ -18,11 +18,11 @@ public class ExpectedLineupsResponse {
     }
 
     public List<ExpectedLineup> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineupsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/expectedlineup/ExpectedLineupsResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class ExpectedLineupsResponse {
     private List<ExpectedLineup> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public ExpectedLineupsResponse() {
     }
 
     public List<ExpectedLineup> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/Country.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/Country.java
@@ -1,12 +1,18 @@
 package es.com.kete1987.sportmonks.library.football.model.league;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Country {
     private Long id;
-    private Long continent_id;
+    @SerializedName("continent_id")
+    private Long continentId;
     private String name;
-    private String official_name;
-    private String fifa_name;
-    private String image_path;
+    @SerializedName("official_name")
+    private String officialName;
+    @SerializedName("fifa_name")
+    private String fifaName;
+    @SerializedName("image_path")
+    private String imagePath;
 
     public Country() {
     }
@@ -16,7 +22,7 @@ public class Country {
     }
 
     public Long getContinentId() {
-        return continent_id;
+        return continentId;
     }
 
     public String getName() {
@@ -24,14 +30,14 @@ public class Country {
     }
 
     public String getOfficialName() {
-        return official_name;
+        return officialName;
     }
 
     public String getFifaName() {
-        return fifa_name;
+        return fifaName;
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/League.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/League.java
@@ -3,19 +3,28 @@ package es.com.kete1987.sportmonks.library.football.model.league;
 import es.com.kete1987.sportmonks.library.football.model.season.SeasonData;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class League {
     private Long id;
-    private Long sport_id;
-    private Long country_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("country_id")
+    private Long countryId;
     private String name;
     private Boolean active;
-    private String short_code;
-    private String image_path;
+    @SerializedName("short_code")
+    private String shortCode;
+    @SerializedName("image_path")
+    private String imagePath;
     private String type;
-    private String sub_type;
-    private String last_playerd_at;
-    private Boolean has_jerseys;
+    @SerializedName("sub_type")
+    private String subType;
+    @SerializedName("last_playerd_at")
+    private String lastPlayerdAt;
+    @SerializedName("has_jerseys")
+    private Boolean hasJerseys;
     private List<SeasonData> seasons;
     private SeasonData currentseason;
     private Country country;
@@ -28,11 +37,11 @@ public class League {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public String getName() {
@@ -44,11 +53,11 @@ public class League {
     }
 
     public String getShortCode() {
-        return short_code;
+        return shortCode;
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getType() {
@@ -56,19 +65,19 @@ public class League {
     }
 
     public String getSubType() {
-        return sub_type;
+        return subType;
     }
 
     public String getLastPlayerdAt() {
-        return last_playerd_at;
+        return lastPlayerdAt;
     }
 
     public Boolean getHasJerseys() {
-        return has_jerseys;
+        return hasJerseys;
     }
 
     public List<SeasonData> getSeasons() {
-        return seasons;
+        return seasons == null ? null : Collections.unmodifiableList(seasons);
     }
 
     public SeasonData getCurrentseason() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/League.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/League.java
@@ -4,7 +4,7 @@ import es.com.kete1987.sportmonks.library.football.model.season.SeasonData;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class League {
     private Long id;
@@ -77,7 +77,7 @@ public class League {
     }
 
     public List<SeasonData> getSeasons() {
-        return seasons == null ? null : Collections.unmodifiableList(seasons);
+        return ModelCollections.unmodifiable(seasons);
     }
 
     public SeasonData getCurrentseason() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeagueResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeagueResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class LeagueResponse {
     private League data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public LeagueResponse() {
@@ -19,11 +22,11 @@ public class LeagueResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeagueResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeagueResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class LeagueResponse {
     private League data;
@@ -22,7 +22,7 @@ public class LeagueResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeaguesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeaguesResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class LeaguesResponse {
     private List<League> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public LeaguesResponse() {
     }
 
     public List<League> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class LeaguesResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeaguesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/league/LeaguesResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class LeaguesResponse {
     private List<League> data;
@@ -20,7 +20,7 @@ public class LeaguesResponse {
     }
 
     public List<League> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class LeaguesResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/EventData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/EventData.java
@@ -1,27 +1,40 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
 import es.com.kete1987.sportmonks.library.football.model.player.Player;
+import com.google.gson.annotations.SerializedName;
 
 public class EventData implements Comparable<Object> {
     private Long id;
-    private Long fixture_id;
-    private Long period_id;
-    private Long participant_id;
-    private Long type_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("period_id")
+    private Long periodId;
+    @SerializedName("participant_id")
+    private Long participantId;
+    @SerializedName("type_id")
+    private Long typeId;
     private String section;
-    private Long player_id;
-    private Long related_player_id;
-    private String player_name;
-    private String related_player_name;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("related_player_id")
+    private Long relatedPlayerId;
+    @SerializedName("player_name")
+    private String playerName;
+    @SerializedName("related_player_name")
+    private String relatedPlayerName;
     private String result;
     private String info;
     private String addition;
     private Long minute;
-    private Long extra_minute;
+    @SerializedName("extra_minute")
+    private Long extraMinute;
     private Boolean injured;
-    private Boolean on_bench;
-    private Long coach_id;
-    private Long sub_type_id;
+    @SerializedName("on_bench")
+    private Boolean onBench;
+    @SerializedName("coach_id")
+    private Long coachId;
+    @SerializedName("sub_type_id")
+    private Long subTypeId;
     private Player player;
 
     public EventData() {
@@ -32,19 +45,19 @@ public class EventData implements Comparable<Object> {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getPeriodId() {
-        return period_id;
+        return periodId;
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public String getSection() {
@@ -52,19 +65,19 @@ public class EventData implements Comparable<Object> {
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getRelatedPlayerId() {
-        return related_player_id;
+        return relatedPlayerId;
     }
 
     public String getPlayerName() {
-        return player_name;
+        return playerName;
     }
 
     public String getRelatedPlayerName() {
-        return related_player_name;
+        return relatedPlayerName;
     }
 
     public String getResult() {
@@ -84,7 +97,7 @@ public class EventData implements Comparable<Object> {
     }
 
     public Long getExtraMinute() {
-        return extra_minute;
+        return extraMinute;
     }
 
     public Boolean getInjured() {
@@ -92,15 +105,15 @@ public class EventData implements Comparable<Object> {
     }
 
     public Boolean getOnBench() {
-        return on_bench;
+        return onBench;
     }
 
     public Long getCoachId() {
-        return coach_id;
+        return coachId;
     }
 
     public Long getSubTypeId() {
-        return sub_type_id;
+        return subTypeId;
     }
 
     public Player getPlayer() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/LineUpData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/LineUpData.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.football.util.StatisticsType;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class LineUpData {
     private Long id;
@@ -84,7 +84,7 @@ public class LineUpData {
     }
 
     public List<LineUpDetails> getDetails() {
-        return details == null ? null : Collections.unmodifiableList(details);
+        return ModelCollections.unmodifiable(details);
     }
 
     public Player getPlayer() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/LineUpData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/LineUpData.java
@@ -5,17 +5,27 @@ import es.com.kete1987.sportmonks.library.football.util.PlayerPosition;
 import es.com.kete1987.sportmonks.library.football.util.StatisticsType;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class LineUpData {
     private Long id;
-    private Long sport_id;
-    private Long fixture_id;
-    private Long player_id;
-    private Long team_id;
-    private Long position_id;
-    private Long type_id;
-    private String player_name;
-    private Long jersey_number;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("position_id")
+    private Long positionId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("player_name")
+    private String playerName;
+    @SerializedName("jersey_number")
+    private Long jerseyNumber;
     private Player player;
     public List<LineUpDetails> details;
 
@@ -27,28 +37,28 @@ public class LineUpData {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getPositionId() {
-        return position_id;
+        return positionId;
     }
 
     public String getPosition() {
-        if (position_id == null) return "";
-        switch (position_id.intValue()) {
+        if (positionId == null) return "";
+        switch (positionId.intValue()) {
             case PlayerPosition.GOALKEEPER: return "P";
             case PlayerPosition.DEFENDER: return "D";
             case PlayerPosition.MIDFIELDER: return "M";
@@ -58,23 +68,23 @@ public class LineUpData {
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public String getPlayerName() {
-        return player_name;
+        return playerName;
     }
 
     public String getDisplayPlayerName() {
-        return player != null && player.getDisplayName() != null ? player.getDisplayName() : player_name;
+        return player != null && player.getDisplayName() != null ? player.getDisplayName() : playerName;
     }
 
     public Long getJerseyNumber() {
-        return jersey_number;
+        return jerseyNumber;
     }
 
     public List<LineUpDetails> getDetails() {
-        return details;
+        return details == null ? null : Collections.unmodifiableList(details);
     }
 
     public Player getPlayer() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/LineUpDetails.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/LineUpDetails.java
@@ -1,12 +1,19 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
+import com.google.gson.annotations.SerializedName;
+
 public class LineUpDetails {
     private Long id;
-    private Long fixture_id;
-    private Long player_id;
-    private Long team_id;
-    private Long lineup_id;
-    private Long type_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("lineup_id")
+    private Long lineupId;
+    @SerializedName("type_id")
+    private Long typeId;
     private LineUpDetailsData data;
 
     public LineUpDetails() {}
@@ -16,23 +23,23 @@ public class LineUpDetails {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getLineupId() {
-        return lineup_id;
+        return lineupId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public LineUpDetailsData getData() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Match.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Match.java
@@ -1,23 +1,35 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
 import es.com.kete1987.sportmonks.library.football.util.MatchStatus;
+import com.google.gson.annotations.SerializedName;
 
-public class Match implements Comparable<Object> {
+public class Match implements Comparable<Match> {
     protected Long id; //ID del partido
-    protected Long sport_id;
-    protected Long league_id;
-    protected Long season_id;
-    protected Long stage_id;
-    protected Long group_id;
-    protected Long aggregate_id;
-    protected Long round_id;
-    protected Long state_id;
-    protected Long venue_id;
+    @SerializedName("sport_id")
+    protected Long sportId;
+    @SerializedName("league_id")
+    protected Long leagueId;
+    @SerializedName("season_id")
+    protected Long seasonId;
+    @SerializedName("stage_id")
+    protected Long stageId;
+    @SerializedName("group_id")
+    protected Long groupId;
+    @SerializedName("aggregate_id")
+    protected Long aggregateId;
+    @SerializedName("round_id")
+    protected Long roundId;
+    @SerializedName("state_id")
+    protected Long stateId;
+    @SerializedName("venue_id")
+    protected Long venueId;
     protected String name;
-    protected String starting_at;
+    @SerializedName("starting_at")
+    protected String startingAt;
     protected String leg;
     protected Long length;
-    protected Long starting_at_timestamp;
+    @SerializedName("starting_at_timestamp")
+    protected Long startingAtTimestamp;
     protected MatchMeta meta;
 
     public Match() {
@@ -28,39 +40,39 @@ public class Match implements Comparable<Object> {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getStageId() {
-        return stage_id;
+        return stageId;
     }
 
     public Long getGroupId() {
-        return group_id;
+        return groupId;
     }
 
     public Long getAggregateId() {
-        return aggregate_id;
+        return aggregateId;
     }
 
     public Long getRoundId() {
-        return round_id;
+        return roundId;
     }
 
     public Long getStateId() {
-        return state_id;
+        return stateId;
     }
 
     public Long getVenueId() {
-        return venue_id;
+        return venueId;
     }
 
     public String getName() {
@@ -68,7 +80,7 @@ public class Match implements Comparable<Object> {
     }
 
     public String getStartingAt() {
-        return starting_at;
+        return startingAt;
     }
 
     public String getLeg() {
@@ -80,7 +92,7 @@ public class Match implements Comparable<Object> {
     }
 
     public Long getStartingAtTimestamp() {
-        return starting_at_timestamp;
+        return startingAtTimestamp;
     }
 
     public MatchMeta getMeta() {
@@ -88,9 +100,7 @@ public class Match implements Comparable<Object> {
     }
 
     @Override
-    public int compareTo(Object o) {
-        Match aux = (Match) o;
-        // getStarting_at_timestamp
+    public int compareTo(Match aux) {
         if (getStateId() != null && aux.getStateId() != null) {
             Long status1 = getStateId();
             Long status2 = aux.getStateId();

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Match.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Match.java
@@ -3,6 +3,8 @@ package es.com.kete1987.sportmonks.library.football.model.match;
 import es.com.kete1987.sportmonks.library.football.util.MatchStatus;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 public class Match implements Comparable<Match> {
     protected Long id; //ID del partido
     @SerializedName("sport_id")
@@ -99,37 +101,40 @@ public class Match implements Comparable<Match> {
         return meta;
     }
 
+    // ---- Ordering: Live (0) → Not Started (1) → Finished (2) → Other (3) ----
+
     @Override
-    public int compareTo(Match aux) {
-        if (getStateId() != null && aux.getStateId() != null) {
-            Long status1 = getStateId();
-            Long status2 = aux.getStateId();
-            if (status1.intValue() == MatchStatus.NOT_STARTED) {
-                if (status2.intValue() == MatchStatus.NOT_STARTED)
-                    return (int) (getStartingAtTimestamp() - aux.getStartingAtTimestamp());
-                else if (MatchStatus.isLiveMatch(status2.intValue()))
-                    return 1;
-                else
-                    return -1;
-            } else if (MatchStatus.isLiveMatch(status1.intValue())) {
-                if (MatchStatus.isLiveMatch(status2.intValue()))
-                    return 0;
-                else
-                    return -1;
-            } else if (MatchStatus.isMatchFinished(status1.intValue())) {
-                if (status2.intValue() == MatchStatus.NOT_STARTED || MatchStatus.isLiveMatch(status2.intValue()))
-                    return 1;
-                else if (MatchStatus.isMatchFinished(status2.intValue()))
-                    return 0;
-                else
-                    return -1;
-            } else {
-                if (status2.intValue() == MatchStatus.NOT_STARTED || MatchStatus.isLiveMatch(status2.intValue()) || MatchStatus.isMatchFinished(status2.intValue()))
-                    return 1;
-                else
-                    return 0;
-            }
+    public int compareTo(Match other) {
+        if (getStateId() == null || other.getStateId() == null) return 0;
+        int p1 = matchPriority(getStateId().intValue());
+        int p2 = matchPriority(other.getStateId().intValue());
+        if (p1 != p2) {
+            return Integer.compare(p1, p2);
+        }
+        // Both not-started: sort ascending by kick-off timestamp
+        if (p1 == 1 && getStartingAtTimestamp() != null && other.getStartingAtTimestamp() != null) {
+            return Long.compare(getStartingAtTimestamp(), other.getStartingAtTimestamp());
         }
         return 0;
+    }
+
+    private static int matchPriority(int stateId) {
+        if (MatchStatus.isLiveMatch(stateId))     return 0;
+        if (stateId == MatchStatus.NOT_STARTED)   return 1;
+        if (MatchStatus.isMatchFinished(stateId)) return 2;
+        return 3;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Match)) return false;
+        Match match = (Match) o;
+        return Objects.equals(id, match.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchData.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class MatchData {
     private MatchDetail data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public MatchData() {
@@ -19,11 +22,11 @@ public class MatchData {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchData.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MatchData {
     private MatchDetail data;
@@ -22,7 +22,7 @@ public class MatchData {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchDetail.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchDetail.java
@@ -9,6 +9,7 @@ import es.com.kete1987.sportmonks.library.football.util.MatchStatus;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MatchDetail extends Match {
     private Venue venue;
@@ -34,7 +35,7 @@ public class MatchDetail extends Match {
     }
 
     public List<LineUpData> getLineups() {
-        return lineups == null ? null : Collections.unmodifiableList(lineups);
+        return ModelCollections.unmodifiable(lineups);
     }
 
     public List<LineUpData> getLineupLocalTeam() {
@@ -94,11 +95,11 @@ public class MatchDetail extends Match {
     }
 
     public List<EventData> getEvents() {
-        return events == null ? null : Collections.unmodifiableList(events);
+        return ModelCollections.unmodifiable(events);
     }
 
     public List<StatisticsData> getStatistics() {
-        return statistics == null ? null : Collections.unmodifiableList(statistics);
+        return ModelCollections.unmodifiable(statistics);
     }
 
     public StatisticsData getStatisticDataByTypeAndTeamId(int teamId, int type) {
@@ -113,11 +114,11 @@ public class MatchDetail extends Match {
     }
 
     public List<Period> getPeriods() {
-        return periods == null ? null : Collections.unmodifiableList(periods);
+        return ModelCollections.unmodifiable(periods);
     }
 
     public List<Team> getParticipants() {
-        return participants == null ? null : Collections.unmodifiableList(participants);
+        return ModelCollections.unmodifiable(participants);
     }
 
     public Team getHomeTeam() {
@@ -143,11 +144,11 @@ public class MatchDetail extends Match {
     }
 
     public List<Scores> getScores() {
-        return scores == null ? null : Collections.unmodifiableList(scores);
+        return ModelCollections.unmodifiable(scores);
     }
 
     public List<Comment> getComments() {
-        return comments == null ? null : Collections.unmodifiableList(comments);
+        return ModelCollections.unmodifiable(comments);
     }
 
     public int getCurrentLocalTeamGoals() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchDetail.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchDetail.java
@@ -26,6 +26,18 @@ public class MatchDetail extends Match {
     public MatchDetail() {
     }
 
+    // MatchDetail adds enrichment fields (lineups, scores, etc.) but identity
+    // is still determined by the match id inherited from Match.
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
     public Venue getVenue() {
         return venue;
     }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchDetail.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchDetail.java
@@ -7,6 +7,7 @@ import es.com.kete1987.sportmonks.library.football.util.LineUpType;
 import es.com.kete1987.sportmonks.library.football.util.MatchStatus;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class MatchDetail extends Match {
@@ -33,13 +34,16 @@ public class MatchDetail extends Match {
     }
 
     public List<LineUpData> getLineups() {
-        return lineups;
+        return lineups == null ? null : Collections.unmodifiableList(lineups);
     }
 
     public List<LineUpData> getLineupLocalTeam() {
+        if (lineups == null || getHomeTeam() == null) {
+            return Collections.emptyList();
+        }
         List<LineUpData> list = new ArrayList<>();
         int homeTeamId = getHomeTeam().getId().intValue();
-        for (LineUpData lud : getLineups()) {
+        for (LineUpData lud : lineups) {
             if (lud.getTypeId().intValue() == LineUpType.LINEUP && lud.getTeamId().intValue() == homeTeamId) {
                 list.add(lud);
             }
@@ -48,9 +52,12 @@ public class MatchDetail extends Match {
     }
 
     public List<LineUpData> getLineupVisitorTeam() {
+        if (lineups == null || getAwayTeam() == null) {
+            return Collections.emptyList();
+        }
         List<LineUpData> list = new ArrayList<>();
         int awayTeamId = getAwayTeam().getId().intValue();
-        for (LineUpData lud : getLineups()) {
+        for (LineUpData lud : lineups) {
             if (lud.getTypeId().intValue() == LineUpType.LINEUP && lud.getTeamId().intValue() == awayTeamId) {
                 list.add(lud);
             }
@@ -59,9 +66,12 @@ public class MatchDetail extends Match {
     }
 
     public List<LineUpData> getBenchLocalTeam() {
+        if (lineups == null || getHomeTeam() == null) {
+            return Collections.emptyList();
+        }
         List<LineUpData> list = new ArrayList<>();
         int homeTeamId = getHomeTeam().getId().intValue();
-        for (LineUpData lud : getLineups()) {
+        for (LineUpData lud : lineups) {
             if (lud.getTypeId().intValue() == LineUpType.BENCH && lud.getTeamId().intValue() == homeTeamId) {
                 list.add(lud);
             }
@@ -70,9 +80,12 @@ public class MatchDetail extends Match {
     }
 
     public List<LineUpData> getBenchVisitorTeam() {
+        if (lineups == null || getAwayTeam() == null) {
+            return Collections.emptyList();
+        }
         List<LineUpData> list = new ArrayList<>();
         int awayTeamId = getAwayTeam().getId().intValue();
-        for (LineUpData lud : getLineups()) {
+        for (LineUpData lud : lineups) {
             if (lud.getTypeId().intValue() == LineUpType.BENCH && lud.getTeamId().intValue() == awayTeamId) {
                 list.add(lud);
             }
@@ -81,15 +94,18 @@ public class MatchDetail extends Match {
     }
 
     public List<EventData> getEvents() {
-        return events;
+        return events == null ? null : Collections.unmodifiableList(events);
     }
 
     public List<StatisticsData> getStatistics() {
-        return statistics;
+        return statistics == null ? null : Collections.unmodifiableList(statistics);
     }
 
     public StatisticsData getStatisticDataByTypeAndTeamId(int teamId, int type) {
-        for (StatisticsData sd : getStatistics()) {
+        if (statistics == null) {
+            return null;
+        }
+        for (StatisticsData sd : statistics) {
             if (sd.getParticipantId().intValue() == teamId && sd.getTypeId().intValue() == type)
                 return sd;
         }
@@ -97,15 +113,18 @@ public class MatchDetail extends Match {
     }
 
     public List<Period> getPeriods() {
-        return periods;
+        return periods == null ? null : Collections.unmodifiableList(periods);
     }
 
     public List<Team> getParticipants() {
-        return participants;
+        return participants == null ? null : Collections.unmodifiableList(participants);
     }
 
     public Team getHomeTeam() {
-        for (Team team : getParticipants()) {
+        if (participants == null) {
+            return null;
+        }
+        for (Team team : participants) {
             if (team.getMeta() != null && team.getMeta().getLocation().equals("home"))
                 return team;
         }
@@ -113,7 +132,10 @@ public class MatchDetail extends Match {
     }
 
     public Team getAwayTeam() {
-        for (Team team : getParticipants()) {
+        if (participants == null) {
+            return null;
+        }
+        for (Team team : participants) {
             if (team.getMeta() != null && team.getMeta().getLocation().equals("away"))
                 return team;
         }
@@ -121,16 +143,16 @@ public class MatchDetail extends Match {
     }
 
     public List<Scores> getScores() {
-        return scores;
+        return scores == null ? null : Collections.unmodifiableList(scores);
     }
 
     public List<Comment> getComments() {
-        return comments;
+        return comments == null ? null : Collections.unmodifiableList(comments);
     }
 
     public int getCurrentLocalTeamGoals() {
-        if (getScores() != null) {
-            for (Scores score : getScores()) {
+        if (scores != null) {
+            for (Scores score : scores) {
                 if (score.getDescription().equalsIgnoreCase("CURRENT") && score.getScore() != null && score.getScore().getParticipant().equalsIgnoreCase("home"))
                     return score.getScore().getGoals().intValue();
             }
@@ -139,8 +161,8 @@ public class MatchDetail extends Match {
     }
 
     public int getCurrentVisitorTeamGoals() {
-        if (getScores() != null) {
-            for (Scores score : getScores()) {
+        if (scores != null) {
+            for (Scores score : scores) {
                 if (score.getDescription().equalsIgnoreCase("CURRENT") && score.getScore() != null && score.getScore().getParticipant().equalsIgnoreCase("away"))
                     return score.getScore().getGoals().intValue();
             }
@@ -149,17 +171,17 @@ public class MatchDetail extends Match {
     }
 
     public boolean isLiveMatch() {
-        return MatchStatus.isLiveMatch(getState().getId().intValue());
+        return state != null && MatchStatus.isLiveMatch(state.getId().intValue());
     }
 
     public boolean isMatchFinished() {
-        return MatchStatus.isMatchFinished(getState().getId().intValue());
+        return state != null && MatchStatus.isMatchFinished(state.getId().intValue());
     }
 
     public Period getCurrentPeriod() {
-        if (getPeriods() != null && getPeriods().size() > 0) {
-            for (Period period : getPeriods()) {
-                if (period.getTypeId() != null && state.getType() != null && state.getType().getId() != null) {
+        if (periods != null && !periods.isEmpty()) {
+            for (Period period : periods) {
+                if (period.getTypeId() != null && state != null && state.getType() != null && state.getType().getId() != null) {
                     if (period.getTypeId().equals(state.getType().getId())) {
                         return period;
                     }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchsResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class MatchsResponse {
     private List<MatchDetail> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public MatchsResponse() {
     }
 
     public List<MatchDetail> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class MatchsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/MatchsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MatchsResponse {
     private List<MatchDetail> data;
@@ -20,7 +20,7 @@ public class MatchsResponse {
     }
 
     public List<MatchDetail> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class MatchsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Period.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Period.java
@@ -1,17 +1,25 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Period {
     private Long id;
-    private Long fixture_id;
-    private Long type_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("type_id")
+    private Long typeId;
     private Long started;
     private Long ended;
-    private Long counts_from;
+    @SerializedName("counts_from")
+    private Long countsFrom;
     private Boolean ticking;
-    private Long sort_order;
+    @SerializedName("sort_order")
+    private Long sortOrder;
     private String description;
-    private Long time_added;
-    private Long period_length;
+    @SerializedName("time_added")
+    private Long timeAdded;
+    @SerializedName("period_length")
+    private Long periodLength;
     private Long minutes;
     private Long seconds;
 
@@ -23,11 +31,11 @@ public class Period {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getStarted() {
@@ -39,7 +47,7 @@ public class Period {
     }
 
     public Long getCountsFrom() {
-        return counts_from;
+        return countsFrom;
     }
 
     public Boolean getTicking() {
@@ -47,7 +55,7 @@ public class Period {
     }
 
     public Long getSortOrder() {
-        return sort_order;
+        return sortOrder;
     }
 
     public String getDescription() {
@@ -55,11 +63,11 @@ public class Period {
     }
 
     public Long getTimeAdded() {
-        return time_added;
+        return timeAdded;
     }
 
     public Long getPeriodLength() {
-        return period_length;
+        return periodLength;
     }
 
     public Long getMinutes() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Scores.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Scores.java
@@ -1,10 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Scores {
     private Long id;
-    private Long fixture_id;
-    private Long type_id;
-    private Long participant_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("participant_id")
+    private Long participantId;
     private Score score;
     private String description;
 
@@ -16,15 +21,15 @@ public class Scores {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public Score getScore() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/State.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/State.java
@@ -1,11 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
+import com.google.gson.annotations.SerializedName;
+
 public class State {
     private Long id;
     private String state;
     private String name;
-    private String short_name;
-    private String developer_name;
+    @SerializedName("short_name")
+    private String shortName;
+    @SerializedName("developer_name")
+    private String developerName;
     private Type type;
 
     public State() {
@@ -24,11 +28,11 @@ public class State {
     }
 
     public String getShortName() {
-        return short_name;
+        return shortName;
     }
 
     public String getDeveloperName() {
-        return developer_name;
+        return developerName;
     }
 
     public Type getType() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/StatisticsData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/StatisticsData.java
@@ -1,10 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
+import com.google.gson.annotations.SerializedName;
+
 public class StatisticsData {
     private Long id;
-    private Long fixture_id;
-    private Long type_id;
-    private Long participant_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("participant_id")
+    private Long participantId;
     private StatisticsDataValue data;
     private String location;
 
@@ -16,15 +21,15 @@ public class StatisticsData {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public StatisticsDataValue getData() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Type.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/match/Type.java
@@ -1,11 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.match;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Type {
     private Long id;
     private String name;
     private String code;
-    private String developer_name;
-    private String model_type;
+    @SerializedName("developer_name")
+    private String developerName;
+    @SerializedName("model_type")
+    private String modelType;
 
     public Type() {
 
@@ -24,10 +28,10 @@ public class Type {
     }
 
     public String getDeveloperName() {
-        return developer_name;
+        return developerName;
     }
 
     public String getModelType() {
-        return model_type;
+        return modelType;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/matchfact/MatchFact.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/matchfact/MatchFact.java
@@ -1,13 +1,20 @@
 package es.com.kete1987.sportmonks.library.football.model.matchfact;
 
+import com.google.gson.annotations.SerializedName;
+
 public class MatchFact {
     private Long id;
-    private Long fixture_id;
-    private Long type_id;
-    private Long participant_id;
-    private String participant_type;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("participant_id")
+    private Long participantId;
+    @SerializedName("participant_type")
+    private String participantType;
     private Object value;
-    private String created_at;
+    @SerializedName("created_at")
+    private String createdAt;
 
     public MatchFact() {
     }
@@ -17,19 +24,19 @@ public class MatchFact {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public String getParticipantType() {
-        return participant_type;
+        return participantType;
     }
 
     public Object getValue() {
@@ -37,6 +44,6 @@ public class MatchFact {
     }
 
     public String getCreatedAt() {
-        return created_at;
+        return createdAt;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/matchfact/MatchFactsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/matchfact/MatchFactsResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class MatchFactsResponse {
     private List<MatchFact> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public MatchFactsResponse() {
     }
 
     public List<MatchFact> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class MatchFactsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/matchfact/MatchFactsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/matchfact/MatchFactsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MatchFactsResponse {
     private List<MatchFact> data;
@@ -20,7 +20,7 @@ public class MatchFactsResponse {
     }
 
     public List<MatchFact> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class MatchFactsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/news/NewsArticle.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/news/NewsArticle.java
@@ -1,15 +1,22 @@
 package es.com.kete1987.sportmonks.library.football.model.news;
 
+import com.google.gson.annotations.SerializedName;
+
 public class NewsArticle {
     private Long id;
-    private Long fixture_id;
-    private Long season_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("season_id")
+    private Long seasonId;
     private String author;
     private String title;
     private String body;
-    private String image_path;
-    private String created_at;
-    private String published_at;
+    @SerializedName("image_path")
+    private String imagePath;
+    @SerializedName("created_at")
+    private String createdAt;
+    @SerializedName("published_at")
+    private String publishedAt;
     private String type;
 
     public NewsArticle() {
@@ -20,11 +27,11 @@ public class NewsArticle {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public String getAuthor() {
@@ -40,15 +47,15 @@ public class NewsArticle {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getCreatedAt() {
-        return created_at;
+        return createdAt;
     }
 
     public String getPublishedAt() {
-        return published_at;
+        return publishedAt;
     }
 
     public String getType() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/news/NewsArticlesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/news/NewsArticlesResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class NewsArticlesResponse {
 
@@ -19,11 +19,11 @@ public class NewsArticlesResponse {
     }
 
     public List<NewsArticle> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/news/NewsArticlesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/news/NewsArticlesResponse.java
@@ -4,27 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class NewsArticlesResponse {
 
     private List<NewsArticle> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public NewsArticlesResponse() {
     }
 
     public List<NewsArticle> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/Player.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/Player.java
@@ -1,23 +1,36 @@
 package es.com.kete1987.sportmonks.library.football.model.player;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Player {
     private Long id;
-    private Long sport_id;
-    private Long country_id;
-    private Long nationality_id;
-    private Long city_id;
-    private Long position_id;
-    private Long detailed_position_id;
-    private Long type_id;
-    private String common_name;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("country_id")
+    private Long countryId;
+    @SerializedName("nationality_id")
+    private Long nationalityId;
+    @SerializedName("city_id")
+    private Long cityId;
+    @SerializedName("position_id")
+    private Long positionId;
+    @SerializedName("detailed_position_id")
+    private Long detailedPositionId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("common_name")
+    private String commonName;
     private String firstname;
     private String lastname;
     private String name;
-    private String display_name;
-    private String image_path;
+    @SerializedName("display_name")
+    private String displayName;
+    @SerializedName("image_path")
+    private String imagePath;
     private Long height;
     private Long weight;
-    private String date_of_birth;
+    @SerializedName("date_of_birth")
+    private String dateOfBirth;
     private String gender;
 
     public Player() {
@@ -28,35 +41,35 @@ public class Player {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public Long getNationalityId() {
-        return nationality_id;
+        return nationalityId;
     }
 
     public Long getCityId() {
-        return city_id;
+        return cityId;
     }
 
     public Long getPositionId() {
-        return position_id;
+        return positionId;
     }
 
     public Long getDetailedPositionId() {
-        return detailed_position_id;
+        return detailedPositionId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public String getCommonName() {
-        return common_name;
+        return commonName;
     }
 
     public String getFirstname() {
@@ -72,11 +85,11 @@ public class Player {
     }
 
     public String getDisplayName() {
-        return display_name;
+        return displayName;
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public Long getHeight() {
@@ -88,7 +101,7 @@ public class Player {
     }
 
     public String getDateOfBirth() {
-        return date_of_birth;
+        return dateOfBirth;
     }
 
     public String getGender() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayerResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayerResponse.java
@@ -5,12 +5,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import java.util.Collections;
 
 public class PlayerResponse {
     @SerializedName("data")
     private Player player;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public PlayerResponse() {
@@ -21,11 +23,11 @@ public class PlayerResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayerResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayerResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class PlayerResponse {
     @SerializedName("data")
@@ -23,7 +23,7 @@ public class PlayerResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayersResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class PlayersResponse {
     private List<Player> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public PlayersResponse() {
     }
 
     public List<Player> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class PlayersResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/PlayersResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class PlayersResponse {
     private List<Player> data;
@@ -20,7 +20,7 @@ public class PlayersResponse {
     }
 
     public List<Player> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class PlayersResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/Sidelined.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/player/Sidelined.java
@@ -1,15 +1,24 @@
 package es.com.kete1987.sportmonks.library.football.model.player;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Sidelined {
     private Long id;
-    private Long player_id;
-    private Long type_id;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("type_id")
+    private Long typeId;
     private String category;
-    private Long team_id;
-    private Long season_id;
-    private String start_date;
-    private String end_date;
-    private Long games_missed;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("start_date")
+    private String startDate;
+    @SerializedName("end_date")
+    private String endDate;
+    @SerializedName("games_missed")
+    private Long gamesMissed;
     private Boolean completed;
 
     public Sidelined() {
@@ -20,11 +29,11 @@ public class Sidelined {
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public String getCategory() {
@@ -32,23 +41,23 @@ public class Sidelined {
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public String getStartDate() {
-        return start_date;
+        return startDate;
     }
 
     public String getEndDdate() {
-        return end_date;
+        return endDate;
     }
 
     public Long getGamesMissed() {
-        return games_missed;
+        return gamesMissed;
     }
 
     public Boolean getCompleted() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/Predictability.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/Predictability.java
@@ -1,15 +1,19 @@
 package es.com.kete1987.sportmonks.library.football.model.prediction;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Predictability {
-    private Long league_id;
+    @SerializedName("league_id")
+    private Long leagueId;
     private Double predictability;
-    private Long season_id;
+    @SerializedName("season_id")
+    private Long seasonId;
 
     public Predictability() {
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Double getPredictability() {
@@ -17,6 +21,6 @@ public class Predictability {
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/PredictabilityResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/PredictabilityResponse.java
@@ -4,27 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class PredictabilityResponse {
 
     private List<Predictability> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public PredictabilityResponse() {
     }
 
     public List<Predictability> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/PredictabilityResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/PredictabilityResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class PredictabilityResponse {
 
@@ -19,11 +19,11 @@ public class PredictabilityResponse {
     }
 
     public List<Predictability> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ProbabilitiesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ProbabilitiesResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class ProbabilitiesResponse {
 
@@ -19,11 +19,11 @@ public class ProbabilitiesResponse {
     }
 
     public List<Probability> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ProbabilitiesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ProbabilitiesResponse.java
@@ -4,27 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class ProbabilitiesResponse {
 
     private List<Probability> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public ProbabilitiesResponse() {
     }
 
     public List<Probability> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/Probability.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/Probability.java
@@ -1,9 +1,13 @@
 package es.com.kete1987.sportmonks.library.football.model.prediction;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Probability {
     private Long id;
-    private Long fixture_id;
-    private Long type_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("type_id")
+    private Long typeId;
     private Double home;
     private Double draw;
     private Double away;
@@ -18,11 +22,11 @@ public class Probability {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Double getHome() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ValueBet.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ValueBet.java
@@ -1,16 +1,24 @@
 package es.com.kete1987.sportmonks.library.football.model.prediction;
 
+import com.google.gson.annotations.SerializedName;
+
 public class ValueBet {
     private Long id;
-    private Long fixture_id;
-    private Long type_id;
-    private Long bookmaker_id;
-    private Long market_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("bookmaker_id")
+    private Long bookmakerId;
+    @SerializedName("market_id")
+    private Long marketId;
     private Double odds;
     private Double value;
     private String label;
-    private Double fair_odds;
-    private String created_at;
+    @SerializedName("fair_odds")
+    private Double fairOdds;
+    @SerializedName("created_at")
+    private String createdAt;
 
     public ValueBet() {
     }
@@ -20,19 +28,19 @@ public class ValueBet {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getBookmakerId() {
-        return bookmaker_id;
+        return bookmakerId;
     }
 
     public Long getMarketId() {
-        return market_id;
+        return marketId;
     }
 
     public Double getOdds() {
@@ -48,10 +56,10 @@ public class ValueBet {
     }
 
     public Double getFairOdds() {
-        return fair_odds;
+        return fairOdds;
     }
 
     public String getCreatedAt() {
-        return created_at;
+        return createdAt;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ValueBetsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ValueBetsResponse.java
@@ -4,27 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class ValueBetsResponse {
 
     private List<ValueBet> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public ValueBetsResponse() {
     }
 
     public List<ValueBet> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ValueBetsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/prediction/ValueBetsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class ValueBetsResponse {
 
@@ -19,11 +19,11 @@ public class ValueBetsResponse {
     }
 
     public List<ValueBet> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/Referee.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/Referee.java
@@ -1,15 +1,23 @@
 package es.com.kete1987.sportmonks.library.football.model.referee;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Referee {
     private Long id;
-    private Long sport_id;
-    private Long country_id;
-    private Long city_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("country_id")
+    private Long countryId;
+    @SerializedName("city_id")
+    private Long cityId;
     private String name;
-    private String display_name;
-    private String image_path;
+    @SerializedName("display_name")
+    private String displayName;
+    @SerializedName("image_path")
+    private String imagePath;
     private String gender;
-    private String date_of_birth;
+    @SerializedName("date_of_birth")
+    private String dateOfBirth;
 
     public Referee() {
     }
@@ -19,15 +27,15 @@ public class Referee {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public Long getCityId() {
-        return city_id;
+        return cityId;
     }
 
     public String getName() {
@@ -35,11 +43,11 @@ public class Referee {
     }
 
     public String getDisplayName() {
-        return display_name;
+        return displayName;
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getGender() {
@@ -47,6 +55,6 @@ public class Referee {
     }
 
     public String getDateOfBirth() {
-        return date_of_birth;
+        return dateOfBirth;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereeResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereeResponse.java
@@ -5,12 +5,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import java.util.Collections;
 
 public class RefereeResponse {
     @SerializedName("data")
     private Referee referee;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public RefereeResponse() {
@@ -21,11 +23,11 @@ public class RefereeResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereeResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereeResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class RefereeResponse {
     @SerializedName("data")
@@ -23,7 +23,7 @@ public class RefereeResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereesResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class RefereesResponse {
     private List<Referee> data;
@@ -20,7 +20,7 @@ public class RefereesResponse {
     }
 
     public List<Referee> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class RefereesResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/referee/RefereesResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class RefereesResponse {
     private List<Referee> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public RefereesResponse() {
     }
 
     public List<Referee> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class RefereesResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rival/Rival.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rival/Rival.java
@@ -1,10 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.rival;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Rival {
     private Long id;
-    private Long sport_id;
-    private Long team_id;
-    private Long rival_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("rival_id")
+    private Long rivalId;
 
     public Rival() {
     }
@@ -14,14 +19,14 @@ public class Rival {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getRivalId() {
-        return rival_id;
+        return rivalId;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rival/RivalsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rival/RivalsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class RivalsResponse {
     private List<Rival> data;
@@ -18,11 +18,11 @@ public class RivalsResponse {
     }
 
     public List<Rival> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rival/RivalsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rival/RivalsResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class RivalsResponse {
     private List<Rival> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public RivalsResponse() {
     }
 
     public List<Rival> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/Round.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/Round.java
@@ -4,7 +4,7 @@ import es.com.kete1987.sportmonks.library.football.model.match.MatchDetail;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class Round {
     private Long id;
@@ -76,6 +76,6 @@ public class Round {
     }
 
     public List<MatchDetail> getFixtures() {
-        return fixtures == null ? null : Collections.unmodifiableList(fixtures);
+        return ModelCollections.unmodifiable(fixtures);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/Round.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/Round.java
@@ -3,19 +3,29 @@ package es.com.kete1987.sportmonks.library.football.model.rounds;
 import es.com.kete1987.sportmonks.library.football.model.match.MatchDetail;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class Round {
     private Long id;
-    private Long sport_id;
-    private Long league_id;
-    private Long season_id;
-    private Long stage_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("stage_id")
+    private Long stageId;
     private String name;
     private Boolean finished;
-    private Boolean is_current;
-    private String starting_at;
-    private String ending_at;
-    private Boolean games_in_current_week;
+    @SerializedName("is_current")
+    private Boolean isCurrent;
+    @SerializedName("starting_at")
+    private String startingAt;
+    @SerializedName("ending_at")
+    private String endingAt;
+    @SerializedName("games_in_current_week")
+    private Boolean gamesInCurrentWeek;
     private List<MatchDetail> fixtures;
 
     public Round() {
@@ -26,19 +36,19 @@ public class Round {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getStageId() {
-        return stage_id;
+        return stageId;
     }
 
     public String getName() {
@@ -50,22 +60,22 @@ public class Round {
     }
 
     public Boolean getIsCurrent() {
-        return is_current;
+        return isCurrent;
     }
 
     public String getStartingAt() {
-        return starting_at;
+        return startingAt;
     }
 
     public String getEndingAt() {
-        return ending_at;
+        return endingAt;
     }
 
     public Boolean getGamesInCurrentWeek() {
-        return games_in_current_week;
+        return gamesInCurrentWeek;
     }
 
     public List<MatchDetail> getFixtures() {
-        return fixtures;
+        return fixtures == null ? null : Collections.unmodifiableList(fixtures);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class RoundResponse {
     private Round data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public Round getData() {
@@ -16,11 +19,11 @@ public class RoundResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class RoundResponse {
     private Round data;
@@ -19,7 +19,7 @@ public class RoundResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class RoundsResponse {
     private List<Round> data;
@@ -15,11 +15,11 @@ public class RoundsResponse {
     private String timezone;
 
     public List<Round> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/rounds/RoundsResponse.java
@@ -4,23 +4,26 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class RoundsResponse {
     private List<Round> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public List<Round> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/Schedule.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/Schedule.java
@@ -3,24 +3,28 @@ package es.com.kete1987.sportmonks.library.football.model.schedule;
 import es.com.kete1987.sportmonks.library.football.model.rounds.Round;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class Schedule {
-    private Long season_id;
-    private Long team_id;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("team_id")
+    private Long teamId;
     private List<Round> rounds;
 
     public Schedule() {
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public List<Round> getRounds() {
-        return rounds;
+        return rounds == null ? null : Collections.unmodifiableList(rounds);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/Schedule.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/Schedule.java
@@ -4,7 +4,7 @@ import es.com.kete1987.sportmonks.library.football.model.rounds.Round;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class Schedule {
     @SerializedName("season_id")
@@ -25,6 +25,6 @@ public class Schedule {
     }
 
     public List<Round> getRounds() {
-        return rounds == null ? null : Collections.unmodifiableList(rounds);
+        return ModelCollections.unmodifiable(rounds);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/SchedulesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/SchedulesResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class SchedulesResponse {
     private List<Schedule> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public SchedulesResponse() {
     }
 
     public List<Schedule> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/SchedulesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/schedule/SchedulesResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class SchedulesResponse {
     private List<Schedule> data;
@@ -18,11 +18,11 @@ public class SchedulesResponse {
     }
 
     public List<Schedule> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonData.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.football.model.stage.Stage;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class SeasonData {
     private Long id;
@@ -83,10 +83,10 @@ public class SeasonData {
     }
 
     public List<Stage> getStages() {
-        return stages == null ? null : Collections.unmodifiableList(stages);
+        return ModelCollections.unmodifiable(stages);
     }
 
     public List<Match> getFixtures() {
-        return fixtures == null ? null : Collections.unmodifiableList(fixtures);
+        return ModelCollections.unmodifiable(fixtures);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonData.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonData.java
@@ -4,20 +4,30 @@ import es.com.kete1987.sportmonks.library.football.model.match.Match;
 import es.com.kete1987.sportmonks.library.football.model.stage.Stage;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class SeasonData {
     private Long id;
-    private Long sport_id;
-    private Long league_id;
-    private Long tie_breaker_rule_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("tie_breaker_rule_id")
+    private Long tieBreakerRuleId;
     private String name;
     private Boolean finished;
     private Boolean pending;
-    private Boolean is_current;
-    private String starting_at;
-    private String ending_at;
-    private String standings_recalculated_at;
-    private Boolean games_in_current_week;
+    @SerializedName("is_current")
+    private Boolean isCurrent;
+    @SerializedName("starting_at")
+    private String startingAt;
+    @SerializedName("ending_at")
+    private String endingAt;
+    @SerializedName("standings_recalculated_at")
+    private String standingsRecalculatedAt;
+    @SerializedName("games_in_current_week")
+    private Boolean gamesInCurrentWeek;
     private List<Stage> stages;
     private List<Match> fixtures;
 
@@ -29,15 +39,15 @@ public class SeasonData {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getTieBreakerRuleId() {
-        return tie_breaker_rule_id;
+        return tieBreakerRuleId;
     }
 
     public String getName() {
@@ -53,30 +63,30 @@ public class SeasonData {
     }
 
     public Boolean getIsCurrent() {
-        return is_current;
+        return isCurrent;
     }
 
     public String getStartingAt() {
-        return starting_at;
+        return startingAt;
     }
 
     public String getEndingAt() {
-        return ending_at;
+        return endingAt;
     }
 
     public String getStandingsRecalculatedAt() {
-        return standings_recalculated_at;
+        return standingsRecalculatedAt;
     }
 
     public Boolean getGamesInCurrentWeek() {
-        return games_in_current_week;
+        return gamesInCurrentWeek;
     }
 
     public List<Stage> getStages() {
-        return stages;
+        return stages == null ? null : Collections.unmodifiableList(stages);
     }
 
     public List<Match> getFixtures() {
-        return fixtures;
+        return fixtures == null ? null : Collections.unmodifiableList(fixtures);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonDataResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonDataResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class SeasonDataResponse {
     @SerializedName("data")
@@ -23,7 +23,7 @@ public class SeasonDataResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonDataResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonDataResponse.java
@@ -5,12 +5,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import java.util.Collections;
 
 public class SeasonDataResponse {
     @SerializedName("data")
     private SeasonData seasonData;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public SeasonDataResponse() {
@@ -21,11 +23,11 @@ public class SeasonDataResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonsResponse.java
@@ -5,11 +5,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class SeasonsResponse {
     private List<SeasonData> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
     private Pagination pagination;
 
@@ -17,15 +20,15 @@ public class SeasonsResponse {
     }
 
     public List<SeasonData> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/season/SeasonsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class SeasonsResponse {
     private List<SeasonData> data;
@@ -20,11 +20,11 @@ public class SeasonsResponse {
     }
 
     public List<SeasonData> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/squad/SquadPlayer.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/squad/SquadPlayer.java
@@ -1,32 +1,39 @@
 package es.com.kete1987.sportmonks.library.football.model.squad;
 
+import com.google.gson.annotations.SerializedName;
+
 public class SquadPlayer {
-    private Long player_id;
-    private Long team_id;
-    private Long position_id;
-    private Long jersey_number;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("position_id")
+    private Long positionId;
+    @SerializedName("jersey_number")
+    private Long jerseyNumber;
     private String start;
     private String end;
     private Boolean captain;
-    private Long transfer_id;
+    @SerializedName("transfer_id")
+    private Long transferId;
 
     public SquadPlayer() {
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getPositionId() {
-        return position_id;
+        return positionId;
     }
 
     public Long getJerseyNumber() {
-        return jersey_number;
+        return jerseyNumber;
     }
 
     public String getStart() {
@@ -42,6 +49,6 @@ public class SquadPlayer {
     }
 
     public Long getTransferId() {
-        return transfer_id;
+        return transferId;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/squad/SquadPlayersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/squad/SquadPlayersResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class SquadPlayersResponse {
     private List<SquadPlayer> data;
@@ -18,11 +18,11 @@ public class SquadPlayersResponse {
     }
 
     public List<SquadPlayer> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/squad/SquadPlayersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/squad/SquadPlayersResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class SquadPlayersResponse {
     private List<SquadPlayer> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public SquadPlayersResponse() {
     }
 
     public List<SquadPlayer> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/Stage.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/Stage.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.football.model.standings.StandingsGrou
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class Stage implements Comparable<Object> {
     private Long id;
@@ -85,15 +85,15 @@ public class Stage implements Comparable<Object> {
     }
 
     public List<MatchDetail> getFixtures() {
-        return fixtures == null ? null : Collections.unmodifiableList(fixtures);
+        return ModelCollections.unmodifiable(fixtures);
     }
 
     public List<StageAggregate> getAggregates() {
-        return aggregates == null ? null : Collections.unmodifiableList(aggregates);
+        return ModelCollections.unmodifiable(aggregates);
     }
 
     public List<StandingsGroup> getGroups() {
-        return groups == null ? null : Collections.unmodifiableList(groups);
+        return ModelCollections.unmodifiable(groups);
     }
 
     @Override

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/Stage.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/Stage.java
@@ -4,20 +4,31 @@ import es.com.kete1987.sportmonks.library.football.model.match.MatchDetail;
 import es.com.kete1987.sportmonks.library.football.model.standings.StandingsGroup;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class Stage implements Comparable<Object> {
     private Long id;
-    private Long sport_id;
-    private Long league_id;
-    private Long season_id;
-    private Long type_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("type_id")
+    private Long typeId;
     private String name;
-    private Long sort_order;
+    @SerializedName("sort_order")
+    private Long sortOrder;
     private Boolean finished;
-    private Boolean is_current;
-    private String starting_at;
-    private String ending_at;
-    private String games_in_current_week;
+    @SerializedName("is_current")
+    private Boolean isCurrent;
+    @SerializedName("starting_at")
+    private String startingAt;
+    @SerializedName("ending_at")
+    private String endingAt;
+    @SerializedName("games_in_current_week")
+    private String gamesInCurrentWeek;
     private List<MatchDetail> fixtures;
     private List<StageAggregate> aggregates;
     private List<StandingsGroup> groups;
@@ -30,19 +41,19 @@ public class Stage implements Comparable<Object> {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public String getName() {
@@ -50,7 +61,7 @@ public class Stage implements Comparable<Object> {
     }
 
     public Long getSortOrder() {
-        return sort_order;
+        return sortOrder;
     }
 
     public Boolean getFinished() {
@@ -58,31 +69,31 @@ public class Stage implements Comparable<Object> {
     }
 
     public Boolean getIsCurrent() {
-        return is_current;
+        return isCurrent;
     }
 
     public String getStartingAt() {
-        return starting_at;
+        return startingAt;
     }
 
     public String getEndingAt() {
-        return ending_at;
+        return endingAt;
     }
 
     public String getGamesInCurrentWeek() {
-        return games_in_current_week;
+        return gamesInCurrentWeek;
     }
 
     public List<MatchDetail> getFixtures() {
-        return fixtures;
+        return fixtures == null ? null : Collections.unmodifiableList(fixtures);
     }
 
     public List<StageAggregate> getAggregates() {
-        return aggregates;
+        return aggregates == null ? null : Collections.unmodifiableList(aggregates);
     }
 
     public List<StandingsGroup> getGroups() {
-        return groups;
+        return groups == null ? null : Collections.unmodifiableList(groups);
     }
 
     @Override
@@ -93,7 +104,7 @@ public class Stage implements Comparable<Object> {
         int cmp = Long.compare(this.getSortOrder(), other.getSortOrder());
         if (cmp != 0) return cmp;
 
-        // Desempatar por ending_at (nulls al final)
+        // Desempatar por endingAt (nulls al final)
         String thisEnd = this.getEndingAt();
         String otherEnd = other.getEndingAt();
 

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageAggregate.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageAggregate.java
@@ -1,17 +1,24 @@
 package es.com.kete1987.sportmonks.library.football.model.stage;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class StageAggregate {
     private Long id;
-    private Long league_id;
-    private Long season_id;
-    private Long stage_id;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("stage_id")
+    private Long stageId;
     private String name;
-    private List<Long> fixture_ids;
+    @SerializedName("fixture_ids")
+    private List<Long> fixtureIds;
     private String result;
     private String detail;
-    private Long winner_participant_id;
+    @SerializedName("winner_participant_id")
+    private Long winnerParticipantId;
 
     private StageAggregate() {
 
@@ -22,15 +29,15 @@ public class StageAggregate {
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getStageId() {
-        return stage_id;
+        return stageId;
     }
 
     public String getName() {
@@ -38,7 +45,7 @@ public class StageAggregate {
     }
 
     public List<Long> getFixtureIds() {
-        return fixture_ids;
+        return fixtureIds == null ? null : Collections.unmodifiableList(fixtureIds);
     }
 
     public String getResult() {
@@ -50,6 +57,6 @@ public class StageAggregate {
     }
 
     public Long getWinnerParticipantId() {
-        return winner_participant_id;
+        return winnerParticipantId;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageAggregate.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageAggregate.java
@@ -2,7 +2,7 @@ package es.com.kete1987.sportmonks.library.football.model.stage;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class StageAggregate {
     private Long id;
@@ -45,7 +45,7 @@ public class StageAggregate {
     }
 
     public List<Long> getFixtureIds() {
-        return fixtureIds == null ? null : Collections.unmodifiableList(fixtureIds);
+        return ModelCollections.unmodifiable(fixtureIds);
     }
 
     public String getResult() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class StageResponse {
     private Stage data;
@@ -22,7 +22,7 @@ public class StageResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StageResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class StageResponse {
     private Stage data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public StageResponse() {
@@ -19,11 +22,11 @@ public class StageResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StagesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StagesResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class StagesResponse {
     private List<Stage> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public StagesResponse() {
     }
 
     public List<Stage> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StagesResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/stage/StagesResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class StagesResponse {
     private List<Stage> data;
@@ -18,11 +18,11 @@ public class StagesResponse {
     }
 
     public List<Stage> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/Standings.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/Standings.java
@@ -7,7 +7,7 @@ import es.com.kete1987.sportmonks.library.football.model.team.Team;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class Standings {
     private Long id;
@@ -99,7 +99,7 @@ public class Standings {
     }
 
     public List<StandingsDetail> getDetails() {
-        return details == null ? null : Collections.unmodifiableList(details);
+        return ModelCollections.unmodifiable(details);
     }
 
     public Team getParticipant() {
@@ -107,7 +107,7 @@ public class Standings {
     }
 
     public List<StandingsForm> getForm() {
-        return form == null ? null : Collections.unmodifiableList(form);
+        return ModelCollections.unmodifiable(form);
     }
 
     public Stage getStage() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/Standings.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/Standings.java
@@ -6,17 +6,27 @@ import es.com.kete1987.sportmonks.library.football.model.stage.Stage;
 import es.com.kete1987.sportmonks.library.football.model.team.Team;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class Standings {
     private Long id;
-    private Long participant_id;
-    private Long sport_id;
-    private Long league_id;
-    private Long season_id;
-    private Long stage_id;
-    private Long group_id;
-    private Long round_id;
-    private Long standing_rule_id;
+    @SerializedName("participant_id")
+    private Long participantId;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("stage_id")
+    private Long stageId;
+    @SerializedName("group_id")
+    private Long groupId;
+    @SerializedName("round_id")
+    private Long roundId;
+    @SerializedName("standing_rule_id")
+    private Long standingRuleId;
     private Long position;
     private String result;
     private Long points;
@@ -37,35 +47,35 @@ public class Standings {
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getStageId() {
-        return stage_id;
+        return stageId;
     }
 
     public Long getGroupId() {
-        return group_id;
+        return groupId;
     }
 
     public Long getRoundId() {
-        return round_id;
+        return roundId;
     }
 
     public Long getStandingRuleId() {
-        return standing_rule_id;
+        return standingRuleId;
     }
 
     public Long getPosition() {
@@ -89,7 +99,7 @@ public class Standings {
     }
 
     public List<StandingsDetail> getDetails() {
-        return details;
+        return details == null ? null : Collections.unmodifiableList(details);
     }
 
     public Team getParticipant() {
@@ -97,7 +107,7 @@ public class Standings {
     }
 
     public List<StandingsForm> getForm() {
-        return form;
+        return form == null ? null : Collections.unmodifiableList(form);
     }
 
     public Stage getStage() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsDetail.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsDetail.java
@@ -1,10 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.standings;
 
+import com.google.gson.annotations.SerializedName;
+
 public class StandingsDetail {
     private Long id;
-    private String standing_type;
-    private Long standing_id;
-    private Long type_id;
+    @SerializedName("standing_type")
+    private String standingType;
+    @SerializedName("standing_id")
+    private Long standingId;
+    @SerializedName("type_id")
+    private Long typeId;
     private Long value;
 
     public StandingsDetail() {
@@ -15,15 +20,15 @@ public class StandingsDetail {
     }
 
     public String getStandingType() {
-        return standing_type;
+        return standingType;
     }
 
     public Long getStandingId() {
-        return standing_id;
+        return standingId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getValue() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsForm.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsForm.java
@@ -1,12 +1,18 @@
 package es.com.kete1987.sportmonks.library.football.model.standings;
 
+import com.google.gson.annotations.SerializedName;
+
 public class StandingsForm {
     private Long id;
-    private String standing_type;
-    private Long standing_id;
-    private Long fixture_id;
+    @SerializedName("standing_type")
+    private String standingType;
+    @SerializedName("standing_id")
+    private Long standingId;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
     private String form;
-    private Long sort_order;
+    @SerializedName("sort_order")
+    private Long sortOrder;
 
     public StandingsForm() {
     }
@@ -16,15 +22,15 @@ public class StandingsForm {
     }
 
     public String getStandingType() {
-        return standing_type;
+        return standingType;
     }
 
     public Long getStandingId() {
-        return standing_id;
+        return standingId;
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public String getForm() {
@@ -32,6 +38,6 @@ public class StandingsForm {
     }
 
     public Long getSortOrder() {
-        return sort_order;
+        return sortOrder;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsGroup.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsGroup.java
@@ -1,17 +1,28 @@
 package es.com.kete1987.sportmonks.library.football.model.standings;
 
+import com.google.gson.annotations.SerializedName;
+
 public class StandingsGroup {
     private Long id;
-    private Long sport_id;
-    private Long league_id;
-    private Long season_id;
-    private Long stage_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("stage_id")
+    private Long stageId;
     private String name;
-    private String starting_at;
-    private String ending_at;
-    private Boolean games_in_current_week;
-    private Boolean is_current;
-    private Boolean is_finished;
+    @SerializedName("starting_at")
+    private String startingAt;
+    @SerializedName("ending_at")
+    private String endingAt;
+    @SerializedName("games_in_current_week")
+    private Boolean gamesInCurrentWeek;
+    @SerializedName("is_current")
+    private Boolean isCurrent;
+    @SerializedName("is_finished")
+    private Boolean isFinished;
     private Boolean pending;
 
     public StandingsGroup() {
@@ -22,19 +33,19 @@ public class StandingsGroup {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getStageId() {
-        return stage_id;
+        return stageId;
     }
 
     public String getName() {
@@ -42,23 +53,23 @@ public class StandingsGroup {
     }
 
     public String getStartingAt() {
-        return starting_at;
+        return startingAt;
     }
 
     public String getEndingAt() {
-        return ending_at;
+        return endingAt;
     }
 
     public Boolean getGamesInCurrentWeek() {
-        return games_in_current_week;
+        return gamesInCurrentWeek;
     }
 
     public Boolean getIsCurrent() {
-        return is_current;
+        return isCurrent;
     }
 
     public Boolean getIsFinished() {
-        return is_finished;
+        return isFinished;
     }
 
     public Boolean getPending() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class StandingsResponse {
     private List<Standings> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public StandingsResponse() {
     }
 
     public List<Standings> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class StandingsResponse {
     private List<Standings> data;
@@ -18,11 +18,11 @@ public class StandingsResponse {
     }
 
     public List<Standings> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsRule.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/standings/StandingsRule.java
@@ -1,10 +1,15 @@
 package es.com.kete1987.sportmonks.library.football.model.standings;
 
+import com.google.gson.annotations.SerializedName;
+
 public class StandingsRule {
     private Long id;
-    private String model_type;
-    private Long model_id;
-    private Long type_id;
+    @SerializedName("model_type")
+    private String modelType;
+    @SerializedName("model_id")
+    private Long modelId;
+    @SerializedName("type_id")
+    private Long typeId;
     private Long position;
 
     public StandingsRule() {
@@ -15,15 +20,15 @@ public class StandingsRule {
     }
 
     public String getModelType() {
-        return model_type;
+        return modelType;
     }
 
     public Long getModelId() {
-        return model_id;
+        return modelId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getPosition() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/statistic/Statistic.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/statistic/Statistic.java
@@ -1,13 +1,20 @@
 package es.com.kete1987.sportmonks.library.football.model.statistic;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Statistic {
     private Long id;
-    private Long type_id;
-    private Long participant_id;
-    private String participant_type;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("participant_id")
+    private Long participantId;
+    @SerializedName("participant_type")
+    private String participantType;
     private Object value;
-    private Long season_id;
-    private Long stage_id;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("stage_id")
+    private Long stageId;
 
     public Statistic() {
     }
@@ -17,15 +24,15 @@ public class Statistic {
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public String getParticipantType() {
-        return participant_type;
+        return participantType;
     }
 
     public Object getValue() {
@@ -33,10 +40,10 @@ public class Statistic {
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getStageId() {
-        return stage_id;
+        return stageId;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/statistic/StatisticsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/statistic/StatisticsResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class StatisticsResponse {
     private List<Statistic> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public StatisticsResponse() {
     }
 
     public List<Statistic> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/statistic/StatisticsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/statistic/StatisticsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class StatisticsResponse {
     private List<Statistic> data;
@@ -18,11 +18,11 @@ public class StatisticsResponse {
     }
 
     public List<Statistic> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/Team.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/Team.java
@@ -6,20 +6,28 @@ import es.com.kete1987.sportmonks.library.football.model.season.SeasonData;
 import es.com.kete1987.sportmonks.library.football.model.venue.Venue;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class Team {
     private Long id;
-    private Long sport_id;
-    private Long country_id;
-    private Long venue_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("country_id")
+    private Long countryId;
+    @SerializedName("venue_id")
+    private Long venueId;
     private String gender;
     private String name;
-    private String short_code;
-    private String image_path;
+    @SerializedName("short_code")
+    private String shortCode;
+    @SerializedName("image_path")
+    private String imagePath;
     private Long founded;
     private String type;
     private Boolean placeholder;
-    private String last_played_at;
+    @SerializedName("last_played_at")
+    private String lastPlayedAt;
     private Venue venue;
     private List<TeamPlayer> players;
     private List<Match> latest;
@@ -39,15 +47,15 @@ public class Team {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public Long getVenueId() {
-        return venue_id;
+        return venueId;
     }
 
     public String getName() {
@@ -55,7 +63,7 @@ public class Team {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public Long getFounded() {
@@ -63,7 +71,7 @@ public class Team {
     }
 
     public String getLastPlayedAt() {
-        return last_played_at;
+        return lastPlayedAt;
     }
 
     public String getGender() {
@@ -71,7 +79,7 @@ public class Team {
     }
 
     public String getShortCode() {
-        return short_code;
+        return shortCode;
     }
 
     public String getType() {
@@ -91,30 +99,30 @@ public class Team {
     }
 
     public List<TeamPlayer> getPlayers() {
-        return players;
+        return players == null ? null : Collections.unmodifiableList(players);
     }
 
     public List<Match> getLatest() {
-        return latest;
+        return latest == null ? null : Collections.unmodifiableList(latest);
     }
 
     public List<Match> getUpcoming() {
-        return upcoming;
+        return upcoming == null ? null : Collections.unmodifiableList(upcoming);
     }
 
     public List<SeasonData> getSeasons() {
-        return seasons;
+        return seasons == null ? null : Collections.unmodifiableList(seasons);
     }
 
     public List<SeasonData> getActiveSeasons() {
-        return activeseasons;
+        return activeseasons == null ? null : Collections.unmodifiableList(activeseasons);
     }
 
     public List<Sidelined> getSidelined() {
-        return sidelined;
+        return sidelined == null ? null : Collections.unmodifiableList(sidelined);
     }
 
     public List<Sidelined> getSidelinedhistory() {
-        return sidelinedhistory;
+        return sidelinedhistory == null ? null : Collections.unmodifiableList(sidelinedhistory);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/Team.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/Team.java
@@ -7,7 +7,7 @@ import es.com.kete1987.sportmonks.library.football.model.venue.Venue;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class Team {
     private Long id;
@@ -99,30 +99,30 @@ public class Team {
     }
 
     public List<TeamPlayer> getPlayers() {
-        return players == null ? null : Collections.unmodifiableList(players);
+        return ModelCollections.unmodifiable(players);
     }
 
     public List<Match> getLatest() {
-        return latest == null ? null : Collections.unmodifiableList(latest);
+        return ModelCollections.unmodifiable(latest);
     }
 
     public List<Match> getUpcoming() {
-        return upcoming == null ? null : Collections.unmodifiableList(upcoming);
+        return ModelCollections.unmodifiable(upcoming);
     }
 
     public List<SeasonData> getSeasons() {
-        return seasons == null ? null : Collections.unmodifiableList(seasons);
+        return ModelCollections.unmodifiable(seasons);
     }
 
     public List<SeasonData> getActiveSeasons() {
-        return activeseasons == null ? null : Collections.unmodifiableList(activeseasons);
+        return ModelCollections.unmodifiable(activeseasons);
     }
 
     public List<Sidelined> getSidelined() {
-        return sidelined == null ? null : Collections.unmodifiableList(sidelined);
+        return ModelCollections.unmodifiable(sidelined);
     }
 
     public List<Sidelined> getSidelinedhistory() {
-        return sidelinedhistory == null ? null : Collections.unmodifiableList(sidelinedhistory);
+        return ModelCollections.unmodifiable(sidelinedhistory);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamPlayer.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamPlayer.java
@@ -1,13 +1,21 @@
 package es.com.kete1987.sportmonks.library.football.model.team;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TeamPlayer {
     private Long id;
-    private Long transfer_id;
-    private Long player_id;
-    private Long team_id;
-    private Long position_id;
-    private Long detailed_position_id;
-    private Long jersey_number;
+    @SerializedName("transfer_id")
+    private Long transferId;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("position_id")
+    private Long positionId;
+    @SerializedName("detailed_position_id")
+    private Long detailedPositionId;
+    @SerializedName("jersey_number")
+    private Long jerseyNumber;
     private String start;
     private String end;
 
@@ -19,27 +27,27 @@ public class TeamPlayer {
     }
 
     public Long getTransferId() {
-        return transfer_id;
+        return transferId;
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getPositionId() {
-        return position_id;
+        return positionId;
     }
 
     public Long getDetailedPositionId() {
-        return detailed_position_id;
+        return detailedPositionId;
     }
 
     public Long getJerseyNumber() {
-        return jersey_number;
+        return jerseyNumber;
     }
 
     public String getStart() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TeamResponse {
     private Team data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TeamResponse() {
@@ -19,11 +22,11 @@ public class TeamResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TeamResponse {
     private Team data;
@@ -22,7 +22,7 @@ public class TeamResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TeamsResponse {
     private List<Team> data;
@@ -20,7 +20,7 @@ public class TeamsResponse {
     }
 
     public List<Team> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class TeamsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/team/TeamsResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TeamsResponse {
     private List<Team> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TeamsResponse() {
     }
 
     public List<Team> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class TeamsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/teamranking/TeamRanking.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/teamranking/TeamRanking.java
@@ -1,13 +1,19 @@
 package es.com.kete1987.sportmonks.library.football.model.teamranking;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TeamRanking {
     private Long id;
-    private Long team_id;
-    private Long league_id;
-    private Long season_id;
+    @SerializedName("team_id")
+    private Long teamId;
+    @SerializedName("league_id")
+    private Long leagueId;
+    @SerializedName("season_id")
+    private Long seasonId;
     private Long position;
     private Long points;
-    private String ranking_date;
+    @SerializedName("ranking_date")
+    private String rankingDate;
 
     public TeamRanking() {
     }
@@ -17,15 +23,15 @@ public class TeamRanking {
     }
 
     public Long getTeamId() {
-        return team_id;
+        return teamId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getPosition() {
@@ -37,6 +43,6 @@ public class TeamRanking {
     }
 
     public String getRankingDate() {
-        return ranking_date;
+        return rankingDate;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/teamranking/TeamRankingsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/teamranking/TeamRankingsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TeamRankingsResponse {
     private List<TeamRanking> data;
@@ -20,7 +20,7 @@ public class TeamRankingsResponse {
     }
 
     public List<TeamRanking> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class TeamRankingsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/teamranking/TeamRankingsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/teamranking/TeamRankingsResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TeamRankingsResponse {
     private List<TeamRanking> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TeamRankingsResponse() {
     }
 
     public List<TeamRanking> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class TeamRankingsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScorersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScorersResponse.java
@@ -5,11 +5,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TopScorersResponse {
     private List<TopScoresPlayer> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
     private Pagination pagination;
 
@@ -17,15 +20,15 @@ public class TopScorersResponse {
     }
 
     public List<TopScoresPlayer> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScorersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScorersResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TopScorersResponse {
     private List<TopScoresPlayer> data;
@@ -20,11 +20,11 @@ public class TopScorersResponse {
     }
 
     public List<TopScoresPlayer> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScoresPlayer.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScoresPlayer.java
@@ -4,15 +4,20 @@ import es.com.kete1987.sportmonks.library.football.model.player.Player;
 import es.com.kete1987.sportmonks.library.football.model.season.SeasonData;
 import es.com.kete1987.sportmonks.library.football.model.stage.Stage;
 import es.com.kete1987.sportmonks.library.football.model.team.Team;
+import com.google.gson.annotations.SerializedName;
 
 public class TopScoresPlayer {
     private Long id;
-    private Long season_id;
-    private Long player_id;
-    private Long type_id;
+    @SerializedName("season_id")
+    private Long seasonId;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("type_id")
+    private Long typeId;
     private Long position;
     private Long total;
-    private Long participant_id;
+    @SerializedName("participant_id")
+    private Long participantId;
     private SeasonData season;
     private Stage stage;
     private Player player;
@@ -27,15 +32,15 @@ public class TopScoresPlayer {
     }
 
     public Long getSeasonId() {
-        return season_id;
+        return seasonId;
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getPosition() {
@@ -47,7 +52,7 @@ public class TopScoresPlayer {
     }
 
     public Long getParticipantId() {
-        return participant_id;
+        return participantId;
     }
 
     public SeasonData getSeason() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScoresType.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/topscorers/TopScoresType.java
@@ -1,12 +1,17 @@
 package es.com.kete1987.sportmonks.library.football.model.topscorers;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TopScoresType {
     private Long id;
     private String name;
     private String code;
-    private String developer_name;
-    private String model_type;
-    private String stat_group;
+    @SerializedName("developer_name")
+    private String developerName;
+    @SerializedName("model_type")
+    private String modelType;
+    @SerializedName("stat_group")
+    private String statGroup;
 
     public TopScoresType() {
     }
@@ -24,14 +29,14 @@ public class TopScoresType {
     }
 
     public String getDeveloperName() {
-        return developer_name;
+        return developerName;
     }
 
     public String getModelType() {
-        return model_type;
+        return modelType;
     }
 
     public String getStatGroup() {
-        return stat_group;
+        return statGroup;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamOfTheWeek.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamOfTheWeek.java
@@ -4,7 +4,7 @@ import es.com.kete1987.sportmonks.library.football.model.player.Player;
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TeamOfTheWeek {
     private Long id;
@@ -36,6 +36,6 @@ public class TeamOfTheWeek {
     }
 
     public List<Player> getPlayers() {
-        return players == null ? null : Collections.unmodifiableList(players);
+        return ModelCollections.unmodifiable(players);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamOfTheWeek.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamOfTheWeek.java
@@ -3,12 +3,17 @@ package es.com.kete1987.sportmonks.library.football.model.totw;
 import es.com.kete1987.sportmonks.library.football.model.player.Player;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TeamOfTheWeek {
     private Long id;
-    private Long fixture_id;
-    private Long round_id;
-    private Long league_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("round_id")
+    private Long roundId;
+    @SerializedName("league_id")
+    private Long leagueId;
     private List<Player> players;
 
     public TeamOfTheWeek() {
@@ -19,18 +24,18 @@ public class TeamOfTheWeek {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getRoundId() {
-        return round_id;
+        return roundId;
     }
 
     public Long getLeagueId() {
-        return league_id;
+        return leagueId;
     }
 
     public List<Player> getPlayers() {
-        return players;
+        return players == null ? null : Collections.unmodifiableList(players);
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamsOfTheWeekResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamsOfTheWeekResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TeamsOfTheWeekResponse {
     private List<TeamOfTheWeek> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TeamsOfTheWeekResponse() {
     }
 
     public List<TeamOfTheWeek> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class TeamsOfTheWeekResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamsOfTheWeekResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/totw/TeamsOfTheWeekResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TeamsOfTheWeekResponse {
     private List<TeamOfTheWeek> data;
@@ -20,7 +20,7 @@ public class TeamsOfTheWeekResponse {
     }
 
     public List<TeamOfTheWeek> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class TeamsOfTheWeekResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/Transfer.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/Transfer.java
@@ -1,14 +1,22 @@
 package es.com.kete1987.sportmonks.library.football.model.transfer;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Transfer {
     private Long id;
-    private Long player_id;
-    private Long type_id;
-    private Long from_team_id;
-    private Long to_team_id;
-    private Long position_id;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("type_id")
+    private Long typeId;
+    @SerializedName("from_team_id")
+    private Long fromTeamId;
+    @SerializedName("to_team_id")
+    private Long toTeamId;
+    @SerializedName("position_id")
+    private Long positionId;
     private String date;
-    private Boolean career_ended;
+    @SerializedName("career_ended")
+    private Boolean careerEnded;
     private Boolean completed;
     private Long amount;
 
@@ -20,23 +28,23 @@ public class Transfer {
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getTypeId() {
-        return type_id;
+        return typeId;
     }
 
     public Long getFromTeamId() {
-        return from_team_id;
+        return fromTeamId;
     }
 
     public Long getToTeamId() {
-        return to_team_id;
+        return toTeamId;
     }
 
     public Long getPositionId() {
-        return position_id;
+        return positionId;
     }
 
     public String getDate() {
@@ -44,7 +52,7 @@ public class Transfer {
     }
 
     public Boolean getCareerEnded() {
-        return career_ended;
+        return careerEnded;
     }
 
     public Boolean getCompleted() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TransferResponse {
     private Transfer data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TransferResponse() {
@@ -19,11 +22,11 @@ public class TransferResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TransferResponse {
     private Transfer data;
@@ -22,7 +22,7 @@ public class TransferResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumour.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumour.java
@@ -1,12 +1,19 @@
 package es.com.kete1987.sportmonks.library.football.model.transfer;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TransferRumour {
     private Long id;
-    private Long player_id;
-    private Long from_team_id;
-    private Long to_team_id;
-    private String start_date;
-    private String end_date;
+    @SerializedName("player_id")
+    private Long playerId;
+    @SerializedName("from_team_id")
+    private Long fromTeamId;
+    @SerializedName("to_team_id")
+    private Long toTeamId;
+    @SerializedName("start_date")
+    private String startDate;
+    @SerializedName("end_date")
+    private String endDate;
 
     public TransferRumour() {
     }
@@ -16,22 +23,22 @@ public class TransferRumour {
     }
 
     public Long getPlayerId() {
-        return player_id;
+        return playerId;
     }
 
     public Long getFromTeamId() {
-        return from_team_id;
+        return fromTeamId;
     }
 
     public Long getToTeamId() {
-        return to_team_id;
+        return toTeamId;
     }
 
     public String getStartDate() {
-        return start_date;
+        return startDate;
     }
 
     public String getEndDate() {
-        return end_date;
+        return endDate;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumourResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumourResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TransferRumourResponse {
     private TransferRumour data;
@@ -22,7 +22,7 @@ public class TransferRumourResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumourResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumourResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TransferRumourResponse {
     private TransferRumour data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TransferRumourResponse() {
@@ -19,11 +22,11 @@ public class TransferRumourResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumoursResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumoursResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TransferRumoursResponse {
     private List<TransferRumour> data;
@@ -20,7 +20,7 @@ public class TransferRumoursResponse {
     }
 
     public List<TransferRumour> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class TransferRumoursResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumoursResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransferRumoursResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TransferRumoursResponse {
     private List<TransferRumour> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TransferRumoursResponse() {
     }
 
     public List<TransferRumour> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class TransferRumoursResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransfersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransfersResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TransfersResponse {
     private List<Transfer> data;
@@ -20,7 +20,7 @@ public class TransfersResponse {
     }
 
     public List<Transfer> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class TransfersResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransfersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/transfer/TransfersResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TransfersResponse {
     private List<Transfer> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TransfersResponse() {
     }
 
     public List<Transfer> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class TransfersResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStation.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStation.java
@@ -1,11 +1,16 @@
 package es.com.kete1987.sportmonks.library.football.model.tvstation;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TvStation {
     private Long id;
-    private Long sport_id;
-    private Long country_id;
+    @SerializedName("sport_id")
+    private Long sportId;
+    @SerializedName("country_id")
+    private Long countryId;
     private String name;
-    private String image_path;
+    @SerializedName("image_path")
+    private String imagePath;
     private String url;
 
     public TvStation() {
@@ -16,11 +21,11 @@ public class TvStation {
     }
 
     public Long getSportId() {
-        return sport_id;
+        return sportId;
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public String getName() {
@@ -28,7 +33,7 @@ public class TvStation {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getUrl() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TvStationResponse {
     private TvStation data;
@@ -22,7 +22,7 @@ public class TvStationResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TvStationResponse {
     private TvStation data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TvStationResponse() {
@@ -19,11 +22,11 @@ public class TvStationResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class TvStationsResponse {
     private List<TvStation> data;
@@ -20,7 +20,7 @@ public class TvStationsResponse {
     }
 
     public List<TvStation> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -28,7 +28,7 @@ public class TvStationsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/tvstation/TvStationsResponse.java
@@ -5,19 +5,22 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class TvStationsResponse {
     private List<TvStation> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public TvStationsResponse() {
     }
 
     public List<TvStation> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -25,11 +28,11 @@ public class TvStationsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/Venue.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/Venue.java
@@ -1,15 +1,21 @@
 package es.com.kete1987.sportmonks.library.football.model.venue;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Venue {
     private Long id;
-    private Long country_id;
-    private Long city_id;
+    @SerializedName("country_id")
+    private Long countryId;
+    @SerializedName("city_id")
+    private Long cityId;
     private String name;
     private String address;
     private Long zipcode;
     private Long capacity;
-    private String image_path;
-    private String city_name;
+    @SerializedName("image_path")
+    private String imagePath;
+    @SerializedName("city_name")
+    private String cityName;
 
     public Venue() {
     }
@@ -19,11 +25,11 @@ public class Venue {
     }
 
     public Long getCountryId() {
-        return country_id;
+        return countryId;
     }
 
     public Long getCityId() {
-        return city_id;
+        return cityId;
     }
 
     public String getName() {
@@ -43,10 +49,10 @@ public class Venue {
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 
     public String getCityName() {
-        return city_name;
+        return cityName;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueDetailResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueDetailResponse.java
@@ -4,11 +4,14 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class VenueDetailResponse {
     private Venue data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public VenueDetailResponse() {
@@ -19,11 +22,11 @@ public class VenueDetailResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueDetailResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueDetailResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class VenueDetailResponse {
     private Venue data;
@@ -22,7 +22,7 @@ public class VenueDetailResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class VenueResponse {
     private List<Venue> data;
@@ -18,11 +18,11 @@ public class VenueResponse {
     }
 
     public List<Venue> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/model/venue/VenueResponse.java
@@ -4,26 +4,29 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class VenueResponse {
     private List<Venue> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public VenueResponse() {
     }
 
     public List<Venue> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/Bookmaker.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/Bookmaker.java
@@ -1,13 +1,20 @@
 package es.com.kete1987.sportmonks.library.odds.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Bookmaker {
     private Long id;
-    private Long legacy_id;
+    @SerializedName("legacy_id")
+    private Long legacyId;
     private String name;
-    private String display_name;
-    private Boolean has_streaming;
-    private Boolean is_premium;
-    private String image_path;
+    @SerializedName("display_name")
+    private String displayName;
+    @SerializedName("has_streaming")
+    private Boolean hasStreaming;
+    @SerializedName("is_premium")
+    private Boolean isPremium;
+    @SerializedName("image_path")
+    private String imagePath;
 
     public Bookmaker() {
     }
@@ -17,7 +24,7 @@ public class Bookmaker {
     }
 
     public Long getLegacyId() {
-        return legacy_id;
+        return legacyId;
     }
 
     public String getName() {
@@ -25,18 +32,18 @@ public class Bookmaker {
     }
 
     public String getDisplayName() {
-        return display_name;
+        return displayName;
     }
 
     public Boolean getHasStreaming() {
-        return has_streaming;
+        return hasStreaming;
     }
 
     public Boolean getIsPremium() {
-        return is_premium;
+        return isPremium;
     }
 
     public String getImagePath() {
-        return image_path;
+        return imagePath;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerMapping.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerMapping.java
@@ -1,22 +1,27 @@
 package es.com.kete1987.sportmonks.library.odds.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public class BookmakerMapping {
-    private Long fixture_id;
-    private Long bookmaker_id;
-    private String fixture_identifier;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("bookmaker_id")
+    private Long bookmakerId;
+    @SerializedName("fixture_identifier")
+    private String fixtureIdentifier;
 
     public BookmakerMapping() {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getBookmakerId() {
-        return bookmaker_id;
+        return bookmakerId;
     }
 
     public String getFixtureIdentifier() {
-        return fixture_identifier;
+        return fixtureIdentifier;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerMappingsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerMappingsResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class BookmakerMappingsResponse {
 
@@ -19,11 +19,11 @@ public class BookmakerMappingsResponse {
     }
 
     public List<BookmakerMapping> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerMappingsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerMappingsResponse.java
@@ -4,27 +4,30 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class BookmakerMappingsResponse {
 
     private List<BookmakerMapping> data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public BookmakerMappingsResponse() {
     }
 
     public List<BookmakerMapping> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerResponse.java
@@ -4,12 +4,15 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class BookmakerResponse {
 
     private Bookmaker data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public BookmakerResponse() {
@@ -20,11 +23,11 @@ public class BookmakerResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakerResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class BookmakerResponse {
 
@@ -23,7 +23,7 @@ public class BookmakerResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakersResponse.java
@@ -5,20 +5,23 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class BookmakersResponse {
 
     private List<Bookmaker> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public BookmakersResponse() {
     }
 
     public List<Bookmaker> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -26,11 +29,11 @@ public class BookmakersResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakersResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/BookmakersResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class BookmakersResponse {
 
@@ -21,7 +21,7 @@ public class BookmakersResponse {
     }
 
     public List<Bookmaker> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -29,7 +29,7 @@ public class BookmakersResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/Market.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/Market.java
@@ -1,11 +1,16 @@
 package es.com.kete1987.sportmonks.library.odds.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Market {
     private Long id;
     private String name;
-    private String display_name;
-    private Boolean has_winning_calculations;
-    private String developer_name;
+    @SerializedName("display_name")
+    private String displayName;
+    @SerializedName("has_winning_calculations")
+    private Boolean hasWinningCalculations;
+    @SerializedName("developer_name")
+    private String developerName;
 
     public Market() {
     }
@@ -19,14 +24,14 @@ public class Market {
     }
 
     public String getDisplayName() {
-        return display_name;
+        return displayName;
     }
 
     public Boolean getHasWinningCalculations() {
-        return has_winning_calculations;
+        return hasWinningCalculations;
     }
 
     public String getDeveloperName() {
-        return developer_name;
+        return developerName;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketResponse.java
@@ -5,7 +5,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MarketResponse {
 
@@ -23,7 +23,7 @@ public class MarketResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketResponse.java
@@ -4,12 +4,15 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class MarketResponse {
 
     private Market data;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public MarketResponse() {
@@ -20,11 +23,11 @@ public class MarketResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class MarketsResponse {
 
@@ -21,7 +21,7 @@ public class MarketsResponse {
     }
 
     public List<Market> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -29,7 +29,7 @@ public class MarketsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/MarketsResponse.java
@@ -5,20 +5,23 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class MarketsResponse {
 
     private List<Market> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public MarketsResponse() {
     }
 
     public List<Market> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -26,11 +29,11 @@ public class MarketsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/Odd.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/Odd.java
@@ -1,14 +1,20 @@
 package es.com.kete1987.sportmonks.library.odds.model;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Odd {
     private Long id;
-    private Long fixture_id;
-    private Long market_id;
-    private Long bookmaker_id;
+    @SerializedName("fixture_id")
+    private Long fixtureId;
+    @SerializedName("market_id")
+    private Long marketId;
+    @SerializedName("bookmaker_id")
+    private Long bookmakerId;
     private String label;
     private String value;
     private String name;
-    private String market_description;
+    @SerializedName("market_description")
+    private String marketDescription;
     private String probability;
     private String dp3;
     private String fractional;
@@ -18,10 +24,14 @@ public class Odd {
     private String total;
     private String handicap;
     private String participants;
-    private String created_at;
-    private String updated_at;
-    private String original_label;
-    private String latest_bookmaker_update;
+    @SerializedName("created_at")
+    private String createdAt;
+    @SerializedName("updated_at")
+    private String updatedAt;
+    @SerializedName("original_label")
+    private String originalLabel;
+    @SerializedName("latest_bookmaker_update")
+    private String latestBookmakerUpdate;
     private Bookmaker bookmaker;
 
     public Odd() {
@@ -32,15 +42,15 @@ public class Odd {
     }
 
     public Long getFixtureId() {
-        return fixture_id;
+        return fixtureId;
     }
 
     public Long getMarketId() {
-        return market_id;
+        return marketId;
     }
 
     public Long getBookmakerId() {
-        return bookmaker_id;
+        return bookmakerId;
     }
 
     public Bookmaker getBookmaker() { return bookmaker; }
@@ -58,7 +68,7 @@ public class Odd {
     }
 
     public String getMarketDescription() {
-        return market_description;
+        return marketDescription;
     }
 
     public String getProbability() {
@@ -98,18 +108,18 @@ public class Odd {
     }
 
     public String getCreatedAt() {
-        return created_at;
+        return createdAt;
     }
 
     public String getUpdatedAt() {
-        return updated_at;
+        return updatedAt;
     }
 
     public String getOriginalLabel() {
-        return original_label;
+        return originalLabel;
     }
 
     public String getLatestBookmakerUpdate() {
-        return latest_bookmaker_update;
+        return latestBookmakerUpdate;
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/OddsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/OddsResponse.java
@@ -5,20 +5,23 @@ import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription;
 
 import java.util.List;
+import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 
 public class OddsResponse {
 
     private List<Odd> data;
     private Pagination pagination;
     private List<Subscription> subscription;
-    private RateLimit rate_limit;
+    @SerializedName("rate_limit")
+    private RateLimit rateLimit;
     private String timezone;
 
     public OddsResponse() {
     }
 
     public List<Odd> getData() {
-        return data;
+        return data == null ? null : Collections.unmodifiableList(data);
     }
 
     public Pagination getPagination() {
@@ -26,11 +29,11 @@ public class OddsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription;
+        return subscription == null ? null : Collections.unmodifiableList(subscription);
     }
 
     public RateLimit getRateLimit() {
-        return rate_limit;
+        return rateLimit;
     }
 
     public String getTimezone() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/odds/model/OddsResponse.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/odds/model/OddsResponse.java
@@ -6,7 +6,7 @@ import es.com.kete1987.sportmonks.library.common.model.subscription.Subscription
 
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
+import es.com.kete1987.sportmonks.library.common.util.ModelCollections;
 
 public class OddsResponse {
 
@@ -21,7 +21,7 @@ public class OddsResponse {
     }
 
     public List<Odd> getData() {
-        return data == null ? null : Collections.unmodifiableList(data);
+        return ModelCollections.unmodifiable(data);
     }
 
     public Pagination getPagination() {
@@ -29,7 +29,7 @@ public class OddsResponse {
     }
 
     public List<Subscription> getSubscription() {
-        return subscription == null ? null : Collections.unmodifiableList(subscription);
+        return ModelCollections.unmodifiable(subscription);
     }
 
     public RateLimit getRateLimit() {

--- a/src/test/java/es/com/kete1987/sportmonks/library/CoachApiTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/CoachApiTest.java
@@ -30,12 +30,17 @@ class CoachApiTest extends BaseApiTest {
         List<Coach> coaches = api.getAllCoaches();
 
         assertEquals(2, coaches.size());
-        assertEquals(1L, coaches.get(0).getId());
-        assertEquals("Erik ten Hag", coaches.get(0).getName());
-        assertEquals("Erik", coaches.get(0).getFirstname());
-        assertEquals("ten Hag", coaches.get(0).getLastname());
-        assertEquals("E. ten Hag", coaches.get(0).getDisplayName());
-        assertEquals("male", coaches.get(0).getGender());
+        Coach first = coaches.get(0);
+        assertEquals(1L, first.getId());
+        assertEquals("Erik ten Hag", first.getName());
+        assertEquals("Erik", first.getFirstname());
+        assertEquals("ten Hag", first.getLastname());
+        assertEquals("E. ten Hag", first.getDisplayName());
+        assertEquals("male", first.getGender());
+        assertEquals(1L, first.getSportId());
+        assertEquals(462L, first.getCountryId());
+        assertEquals(462L, first.getNationalityId());
+        assertEquals("1970-02-02", first.getDateOfBirth());
     }
 
     @Test

--- a/src/test/java/es/com/kete1987/sportmonks/library/LeagueApiTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/LeagueApiTest.java
@@ -19,8 +19,23 @@ class LeagueApiTest extends BaseApiTest {
         List<League> leagues = api.getAllLeagues();
 
         assertEquals(2, leagues.size());
-        assertEquals(8L, leagues.get(0).getId());
-        assertEquals("Premier League", leagues.get(0).getName());
+        League first = leagues.get(0);
+        assertEquals(8L, first.getId());
+        assertEquals("Premier League", first.getName());
+        assertEquals(1L, first.getSportId());
+        assertEquals(462L, first.getCountryId());
+        assertTrue(first.getActive());
+        assertEquals("EPL", first.getShortCode());
+        assertEquals("league", first.getType());
+        assertEquals("domestic", first.getSubType());
+        // fields not in fixture — should be null
+        assertNull(first.getImagePath());
+        assertNull(first.getLastPlayerdAt());
+        assertNull(first.getHasJerseys());
+        assertNull(first.getSeasons());
+        assertNull(first.getCurrentseason());
+        assertNull(first.getCountry());
+
         assertEquals(271L, leagues.get(1).getId());
         assertEquals("Superliga", leagues.get(1).getName());
     }

--- a/src/test/java/es/com/kete1987/sportmonks/library/SeasonApiTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/SeasonApiTest.java
@@ -20,11 +20,19 @@ class SeasonApiTest extends BaseApiTest {
         List<SeasonData> seasons = api.getSeasons();
 
         assertEquals(2, seasons.size());
-        assertEquals(21646, seasons.get(0).getId().intValue());
-        assertEquals("2023/2024", seasons.get(0).getName());
-        assertTrue(seasons.get(0).getFinished());
-        assertEquals(23614, seasons.get(1).getId().intValue());
-        assertTrue(seasons.get(1).getIsCurrent());
+        SeasonData first = seasons.get(0);
+        assertEquals(21646, first.getId().intValue());
+        assertEquals("2023/2024", first.getName());
+        assertTrue(first.getFinished());
+        assertFalse(first.getPending());
+        assertFalse(first.getIsCurrent());
+        assertEquals(1L, first.getSportId());
+        assertEquals(8L, first.getLeagueId());
+
+        SeasonData second = seasons.get(1);
+        assertEquals(23614, second.getId().intValue());
+        assertTrue(second.getIsCurrent());
+        assertFalse(second.getPending());
     }
 
     @Test

--- a/src/test/java/es/com/kete1987/sportmonks/library/StageRoundApiTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/StageRoundApiTest.java
@@ -66,6 +66,14 @@ class StageRoundApiTest extends BaseApiTest {
         assertNotNull(stage);
         assertEquals(1L, stage.getId());
         assertEquals("Regular Season", stage.getName());
+        assertEquals(1L, stage.getSportId());
+        assertEquals(8L, stage.getLeagueId());
+        assertEquals(23614L, stage.getSeasonId());
+        assertFalse(stage.getFinished());
+        assertTrue(stage.getIsCurrent());
+        assertNull(stage.getFixtures());
+        assertNull(stage.getAggregates());
+        assertNull(stage.getGroups());
     }
 
     @Test
@@ -131,7 +139,13 @@ class StageRoundApiTest extends BaseApiTest {
         assertNotNull(round);
         assertEquals(1L, round.getId());
         assertEquals("1", round.getName());
+        assertEquals(1L, round.getSportId());
+        assertEquals(8L, round.getLeagueId());
         assertEquals(23614L, round.getSeasonId());
+        assertEquals(1L, round.getStageId());
+        assertTrue(round.getFinished());
+        assertFalse(round.getIsCurrent());
+        assertNull(round.getFixtures());
     }
 
     @Test

--- a/src/test/java/es/com/kete1987/sportmonks/library/common/util/ModelCollectionsTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/common/util/ModelCollectionsTest.java
@@ -1,0 +1,37 @@
+package es.com.kete1987.sportmonks.library.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModelCollectionsTest {
+
+    @Test
+    void unmodifiable_returnsNullWhenListIsNull() {
+        assertNull(ModelCollections.unmodifiable(null));
+    }
+
+    @Test
+    void unmodifiable_returnsUnmodifiableViewWhenListIsNonNull() {
+        List<String> source = Arrays.asList("a", "b", "c");
+
+        List<String> result = ModelCollections.unmodifiable(source);
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertEquals("a", result.get(0));
+        assertThrows(UnsupportedOperationException.class, () -> result.add("d"),
+                "Result should be unmodifiable");
+    }
+
+    @Test
+    void unmodifiable_emptyListReturnsEmptyUnmodifiableView() {
+        List<String> result = ModelCollections.unmodifiable(List.of());
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Cambios

### `java:S116` — Naming convention (masivo, ~109 ficheros)
Todos los campos `snake_case` de los paquetes `model` ahora tienen
`@SerializedName(nombre_original)` y se renombran a `camelCase`.
Gson sigue mapeando el JSON correctamente mediante la anotación.

**Ejemplo:**
```java
// Antes
private Long region_id;

// Después
@SerializedName(region_id)
private Long regionId;
```

### `java:S2162` — `Comparable` inconsistente (`Match.java`)
`implements Comparable<Object>` → `implements Comparable<Match>`.
Se elimina el cast inseguro `(Match) o` en `compareTo`.

### NPE en `MatchDetail.java`
- `getLineupLocalTeam/VisitorTeam` y `getBenchLocalTeam/VisitorTeam`:
  guard `if (lineups == null || getHomeTeam() == null)` antes de iterar.
- `isLiveMatch()` / `isMatchFinished()`: protegen contra `state == null`.
- `getCurrentPeriod()`: usa `!periods.isEmpty()` en lugar de `size() > 0` (`java:S1155`).

### `java:S2384` — Colecciones mutables expuestas (68 ficheros)
Todos los getters que retornaban una `List` interna directamente ahora
retornan `Collections.unmodifiableList(field)` (o `null` si el campo es null).

## Tests
```
Tests run: 282, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)