### PR TITLE
fix: renombrar constantes a UPPER_SNAKE_CASE (java:S115)

### DIFF
--- a/src/main/java/es/com/kete1987/sportmonks/library/CoreApi.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/CoreApi.java
@@ -54,7 +54,7 @@ public class CoreApi extends SportMonksApiBase {
     }
 
     public CoreApi(String apiToken, String locale) {
-        this(buildHttpClient(apiToken), Constants.baseURLCore, Constants.baseURLMy, locale, new RateLimitTracker());
+        this(buildHttpClient(apiToken), Constants.BASE_URL_CORE, Constants.BASE_URL_MY, locale, new RateLimitTracker());
     }
 
     CoreApi(OkHttpClient client, String coreBase, String myBase, String locale, RateLimitTracker tracker) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/FootballApi.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/FootballApi.java
@@ -93,7 +93,7 @@ public class FootballApi extends SportMonksApiBase {
     }
 
     public FootballApi(String apiToken, String locale) {
-        this(buildHttpClient(apiToken), Constants.baseURLFootball, locale, new RateLimitTracker());
+        this(buildHttpClient(apiToken), Constants.BASE_URL_FOOTBALL, locale, new RateLimitTracker());
     }
 
     FootballApi(OkHttpClient client, String footballBase, String locale, RateLimitTracker tracker) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/OddsApi.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/OddsApi.java
@@ -35,7 +35,7 @@ public class OddsApi extends SportMonksApiBase {
     }
 
     public OddsApi(String apiToken, String locale) {
-        this(buildHttpClient(apiToken), Constants.baseURLOdds, locale, new RateLimitTracker());
+        this(buildHttpClient(apiToken), Constants.BASE_URL_ODDS, locale, new RateLimitTracker());
     }
 
     OddsApi(OkHttpClient client, String oddsBase, String locale, RateLimitTracker tracker) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/PredictionsApi.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/PredictionsApi.java
@@ -34,7 +34,7 @@ public class PredictionsApi extends SportMonksApiBase {
     }
 
     public PredictionsApi(String apiToken, String locale) {
-        this(buildHttpClient(apiToken), Constants.baseURLFootball, locale, new RateLimitTracker());
+        this(buildHttpClient(apiToken), Constants.BASE_URL_FOOTBALL, locale, new RateLimitTracker());
     }
 
     PredictionsApi(OkHttpClient client, String footballBase, String locale, RateLimitTracker tracker) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/SportMonksAPI.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/SportMonksAPI.java
@@ -91,10 +91,10 @@ public class SportMonksAPI {
     public SportMonksAPI(String apiToken, String locale) {
         OkHttpClient client = SportMonksApiBase.buildHttpClient(apiToken);
         this.tracker = new RateLimitTracker();
-        this.football = new FootballApi(client, Constants.baseURLFootball, locale, tracker);
-        this.odds = new OddsApi(client, Constants.baseURLOdds, locale, tracker);
-        this.predictions = new PredictionsApi(client, Constants.baseURLFootball, locale, tracker);
-        this.core = new CoreApi(client, Constants.baseURLCore, Constants.baseURLMy, locale, tracker);
+        this.football = new FootballApi(client, Constants.BASE_URL_FOOTBALL, locale, tracker);
+        this.odds = new OddsApi(client, Constants.BASE_URL_ODDS, locale, tracker);
+        this.predictions = new PredictionsApi(client, Constants.BASE_URL_FOOTBALL, locale, tracker);
+        this.core = new CoreApi(client, Constants.BASE_URL_CORE, Constants.BASE_URL_MY, locale, tracker);
     }
 
     SportMonksAPI(OkHttpClient client, String footballBase, String oddsBase, String coreBase, String myBase) {

--- a/src/main/java/es/com/kete1987/sportmonks/library/common/util/Constants.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/common/util/Constants.java
@@ -3,8 +3,8 @@ package es.com.kete1987.sportmonks.library.common.util;
 public class Constants {
     private Constants() {}
 
-    public static final String baseURLFootball = "https://api.sportmonks.com/v3/football/";
-    public static final String baseURLOdds     = "https://api.sportmonks.com/v3/football/odds/";
-    public static final String baseURLCore     = "https://api.sportmonks.com/v3/core/";
-    public static final String baseURLMy       = "https://api.sportmonks.com/v3/my/";
+    public static final String BASE_URL_FOOTBALL = "https://api.sportmonks.com/v3/football/";
+    public static final String BASE_URL_ODDS      = "https://api.sportmonks.com/v3/football/odds/";
+    public static final String BASE_URL_CORE      = "https://api.sportmonks.com/v3/core/";
+    public static final String BASE_URL_MY        = "https://api.sportmonks.com/v3/my/";
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/football/util/MatchStatus.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/football/util/MatchStatus.java
@@ -2,7 +2,7 @@ package es.com.kete1987.sportmonks.library.football.util;
 
 public class MatchStatus {
     public static final int NOT_STARTED = 1;
-    public static final int INPLAY_1st_HALF = 2;
+    public static final int INPLAY_1ST_HALF = 2;
     public static final int HT = 3; // Half-time
     public static final int BREAK = 4; // Waiting for extra time to start
     public static final int FT = 5; // Full time
@@ -28,7 +28,7 @@ public class MatchStatus {
     public static final int PENDING = 26;
 
     public static boolean isLiveMatch(int status) {
-        return status == INPLAY_1st_HALF || status == HT || status == BREAK || status == INPLAY_ET || status == INPLAY_PENALTIES ||
+        return status == INPLAY_1ST_HALF || status == HT || status == BREAK || status == INPLAY_ET || status == INPLAY_PENALTIES ||
                 status == EXTRA_TIME_BREAK || status == INPLAY_2ND_HALF || status == INPLAY_ET_2ND_HALF || status == PEN_BREAK;
     }
 
@@ -40,7 +40,7 @@ public class MatchStatus {
         switch (status) {
             case NOT_STARTED:
                 return "Sin comenzar";
-            case INPLAY_1st_HALF:
+            case INPLAY_1ST_HALF:
                 return "En juego (1ª parte)";
             case HT:
                 return "Descanso";

--- a/src/test/java/es/com/kete1987/sportmonks/library/PublicConstructorsTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/PublicConstructorsTest.java
@@ -1,0 +1,63 @@
+package es.com.kete1987.sportmonks.library;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Smoke tests for the public (apiToken-based) constructors of each API class.
+ * These constructors build an OkHttpClient and wire it to the production base URL;
+ * they do not make any network calls during construction, so no mock server is needed.
+ */
+class PublicConstructorsTest {
+
+    @Test
+    void footballApi_constructsWithToken() {
+        assertDoesNotThrow(() -> new FootballApi("dummy-token"));
+    }
+
+    @Test
+    void footballApi_constructsWithTokenAndLocale() {
+        assertDoesNotThrow(() -> new FootballApi("dummy-token", "es"));
+    }
+
+    @Test
+    void oddsApi_constructsWithToken() {
+        assertDoesNotThrow(() -> new OddsApi("dummy-token"));
+    }
+
+    @Test
+    void oddsApi_constructsWithTokenAndLocale() {
+        assertDoesNotThrow(() -> new OddsApi("dummy-token", "es"));
+    }
+
+    @Test
+    void predictionsApi_constructsWithToken() {
+        assertDoesNotThrow(() -> new PredictionsApi("dummy-token"));
+    }
+
+    @Test
+    void predictionsApi_constructsWithTokenAndLocale() {
+        assertDoesNotThrow(() -> new PredictionsApi("dummy-token", "es"));
+    }
+
+    @Test
+    void coreApi_constructsWithToken() {
+        assertDoesNotThrow(() -> new CoreApi("dummy-token"));
+    }
+
+    @Test
+    void coreApi_constructsWithTokenAndLocale() {
+        assertDoesNotThrow(() -> new CoreApi("dummy-token", "es"));
+    }
+
+    @Test
+    void sportMonksApi_constructsWithToken() {
+        assertDoesNotThrow(() -> new SportMonksAPI("dummy-token"));
+    }
+
+    @Test
+    void sportMonksApi_constructsWithTokenAndLocale() {
+        assertDoesNotThrow(() -> new SportMonksAPI("dummy-token", "es"));
+    }
+}


### PR DESCRIPTION
## Resumen

Corrige `java:S115` en `Constants.java` y `MatchStatus.java`: las constantes deben seguir el convenio `UPPER_SNAKE_CASE`.

## Cambios

### Renombrado de constantes

| Antes | Después | Archivo |
|-------|---------|---------|
| `baseURLFootball` | `BASE_URL_FOOTBALL` | `Constants.java` |
| `baseURLOdds` | `BASE_URL_ODDS` | `Constants.java` |
| `baseURLCore` | `BASE_URL_CORE` | `Constants.java` |
| `baseURLMy` | `BASE_URL_MY` | `Constants.java` |
| `INPLAY_1st_HALF` | `INPLAY_1ST_HALF` | `MatchStatus.java` |

### Referencias actualizadas

- `SportMonksAPI.java`
- `FootballApi.java`
- `OddsApi.java`
- `PredictionsApi.java`
- `CoreApi.java`

### Tests

`PublicConstructorsTest` — 10 smoke tests para los constructores públicos de cada API (`FootballApi`, `OddsApi`, `PredictionsApi`, `CoreApi`, `SportMonksAPI`). Los constructores solo crean el `OkHttpClient` y configuran la URL; no realizan llamadas de red durante la construcción.

Estos tests cubren las líneas modificadas, garantizando que la PR supere el Quality Gate de cobertura en new code de SonarCloud.

## Verificación

- ✅ 295 tests pasan en local (285 anteriores + 10 nuevos)
- ✅ 0 errores de compilación

🤖 Generated with [Claude Code](https://claude.com/claude-code)