### PR TITLE
feat: expose per-entity rate_limit from the response body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@
 # Local test files with API tokens
 src/main/java/es/com/kete1987/sportmonks/library/APITests.java
 
+# Local maintenance/migration scripts (not part of the build)
+/scripts/
+
 # Claude Code local settings (machine-specific)
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ System.out.println(api.getMaximumRequests());   // "500"
 
 Both return `null` until the first request is made.
 
+Sportmonks also reports rate limits **per entity** in the response body (Sportmonks scopes the
+quota per `requested_entity`). These are captured automatically and accumulated across requests:
+
+```java
+api.getAllLeagues();
+api.getTeamById(1);
+
+RateLimit last = api.getLastRateLimit();          // the most recent call's rate_limit
+System.out.println(last.getRemaining());          // e.g. 2999
+System.out.println(last.getRequestedEntity());    // "team"
+
+Map<String, RateLimit> byEntity = api.getRateLimitsByEntity();
+System.out.println(byEntity.get("league").getRemaining()); // 2999
+System.out.println(byEntity.get("team").getRemaining());   // 2999
+```
+
+`getLastRateLimit()` returns `null` and `getRateLimitsByEntity()` is empty until the first request.
+
 ## Usage Examples
 
 ### Fixtures

--- a/src/main/java/es/com/kete1987/sportmonks/library/RateLimitTracker.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/RateLimitTracker.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Shared, mutable holder for the rate-limit state observed across requests.
@@ -21,11 +22,11 @@ class RateLimitTracker {
     volatile String remaining;
 
     private final Map<String, RateLimit> byEntity = new ConcurrentHashMap<>();
-    private volatile RateLimit last;
+    private final AtomicReference<RateLimit> last = new AtomicReference<>();
 
-    void record(RateLimit rateLimit) {
+    void track(RateLimit rateLimit) {
         if (rateLimit == null) return;
-        last = rateLimit;
+        last.set(rateLimit);
         String entity = rateLimit.getRequestedEntity();
         if (entity != null) {
             byEntity.put(entity, rateLimit);
@@ -33,7 +34,7 @@ class RateLimitTracker {
     }
 
     RateLimit last() {
-        return last;
+        return last.get();
     }
 
     Map<String, RateLimit> byEntity() {

--- a/src/main/java/es/com/kete1987/sportmonks/library/RateLimitTracker.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/RateLimitTracker.java
@@ -1,6 +1,42 @@
 package es.com.kete1987.sportmonks.library;
 
+import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Shared, mutable holder for the rate-limit state observed across requests.
+ *
+ * <p>Two independent signals are tracked. {@link #total}/{@link #remaining} come from the
+ * {@code X-RateLimit-*} HTTP headers and are a single global counter (last response wins).
+ * {@link #byEntity}/{@link #last} come from the {@code rate_limit} object in the response body,
+ * which Sportmonks scopes per {@code requested_entity} (e.g. {@code "league"}, {@code "team"}),
+ * so they are accumulated keyed by entity.
+ */
 class RateLimitTracker {
     volatile String total;
     volatile String remaining;
+
+    private final Map<String, RateLimit> byEntity = new ConcurrentHashMap<>();
+    private volatile RateLimit last;
+
+    void record(RateLimit rateLimit) {
+        if (rateLimit == null) return;
+        last = rateLimit;
+        String entity = rateLimit.getRequestedEntity();
+        if (entity != null) {
+            byEntity.put(entity, rateLimit);
+        }
+    }
+
+    RateLimit last() {
+        return last;
+    }
+
+    Map<String, RateLimit> byEntity() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(byEntity));
+    }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/SportMonksAPI.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/SportMonksAPI.java
@@ -1,5 +1,6 @@
 package es.com.kete1987.sportmonks.library;
 
+import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.util.Constants;
 import es.com.kete1987.sportmonks.library.common.util.SportMonksException;
 import es.com.kete1987.sportmonks.library.core.model.city.City;
@@ -57,9 +58,10 @@ import java.util.TreeMap;
  * Main entry point for the Sportmonks v3 API.
  *
  * <p>Create one instance per API key and reuse it — each instance owns an OkHttp connection
- * pool and a shared {@link RateLimitTracker}. Rate-limit headers are updated automatically
- * after every request and can be read via {@link #getRemainingRequests()} and
- * {@link #getMaximumRequests()}.
+ * pool and a shared {@link RateLimitTracker}. Rate-limit state is updated automatically after every
+ * request: the global {@code X-RateLimit-*} headers via {@link #getRemainingRequests()} and
+ * {@link #getMaximumRequests()}, and the per-entity {@code rate_limit} from the response body via
+ * {@link #getLastRateLimit()} and {@link #getRateLimitsByEntity()}.
  *
  * <p>The facade delegates to four specialised sub-APIs accessible via {@link #getFootball()},
  * {@link #getOdds()}, {@link #getPredictions()}, and {@link #getCore()}.
@@ -115,6 +117,18 @@ public class SportMonksAPI {
 
     /** Returns the value of the {@code X-RateLimit-Limit} header from the last response, or {@code null} if no request has been made yet. */
     public String getMaximumRequests() { return tracker.total; }
+
+    /**
+     * Returns the {@code rate_limit} object from the body of the most recent response (scoped to
+     * that response's {@code requested_entity}), or {@code null} if no request has been made yet.
+     */
+    public RateLimit getLastRateLimit() { return tracker.last(); }
+
+    /**
+     * Returns an immutable snapshot of the latest {@code rate_limit} seen per {@code requested_entity}
+     * (e.g. {@code "league"}, {@code "team"}), accumulated across every request. Empty until the first request.
+     */
+    public Map<String, RateLimit> getRateLimitsByEntity() { return tracker.byEntity(); }
 
     // -------------------------------------------------------------------------
     // Matches / Fixtures

--- a/src/main/java/es/com/kete1987/sportmonks/library/SportMonksApiBase.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/SportMonksApiBase.java
@@ -2,6 +2,8 @@ package es.com.kete1987.sportmonks.library;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.model.subscription.SubscriptionMeta;
 import es.com.kete1987.sportmonks.library.common.model.subscription.SubscriptionMetaDeserializer;
 import es.com.kete1987.sportmonks.library.common.util.EmptyStringToNumberTypeAdapter;
@@ -12,6 +14,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 abstract class SportMonksApiBase {
@@ -54,8 +57,26 @@ abstract class SportMonksApiBase {
             if (!response.isSuccessful()) {
                 throw new SportMonksException(response.code() + " - " + body);
             }
+            recordRateLimit(body);
             return body;
         }
+    }
+
+    private void recordRateLimit(String body) {
+        if (body == null || body.isEmpty()) return;
+        try {
+            RateLimitEnvelope envelope = gson().fromJson(body, RateLimitEnvelope.class);
+            if (envelope != null) {
+                rateLimitTracker.record(envelope.rateLimit);
+            }
+        } catch (RuntimeException ignored) {
+            // rate_limit is best-effort metadata; never fail a request over a parse hiccup.
+        }
+    }
+
+    private static final class RateLimitEnvelope {
+        @SerializedName("rate_limit")
+        RateLimit rateLimit;
     }
 
     HttpUrl.Builder withIncludes(HttpUrl.Builder builder, String... includes) {
@@ -78,5 +99,23 @@ abstract class SportMonksApiBase {
 
     public String getMaximumRequests() {
         return rateLimitTracker.total;
+    }
+
+    /**
+     * Returns the {@code rate_limit} object from the body of the most recent response, or
+     * {@code null} if no request has been made yet. Unlike {@link #getRemainingRequests()} (a
+     * global header counter), this is scoped to the entity that response requested.
+     */
+    public RateLimit getLastRateLimit() {
+        return rateLimitTracker.last();
+    }
+
+    /**
+     * Returns an immutable snapshot of the latest {@code rate_limit} seen for each
+     * {@code requested_entity} (e.g. {@code "league"}, {@code "team"}), accumulated across every
+     * request made through this client. Empty until the first request.
+     */
+    public Map<String, RateLimit> getRateLimitsByEntity() {
+        return rateLimitTracker.byEntity();
     }
 }

--- a/src/main/java/es/com/kete1987/sportmonks/library/SportMonksApiBase.java
+++ b/src/main/java/es/com/kete1987/sportmonks/library/SportMonksApiBase.java
@@ -63,11 +63,11 @@ abstract class SportMonksApiBase {
     }
 
     private void recordRateLimit(String body) {
-        if (body == null || body.isEmpty()) return;
+        if (body.isEmpty()) return;
         try {
             RateLimitEnvelope envelope = gson().fromJson(body, RateLimitEnvelope.class);
             if (envelope != null) {
-                rateLimitTracker.record(envelope.rateLimit);
+                rateLimitTracker.track(envelope.rateLimit);
             }
         } catch (RuntimeException ignored) {
             // rate_limit is best-effort metadata; never fail a request over a parse hiccup.

--- a/src/test/java/es/com/kete1987/sportmonks/library/FixtureApiTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/FixtureApiTest.java
@@ -5,6 +5,7 @@ import es.com.kete1987.sportmonks.library.common.util.SportMonksException;
 import es.com.kete1987.sportmonks.library.football.model.match.EventData;
 import es.com.kete1987.sportmonks.library.football.model.match.MatchDetail;
 import es.com.kete1987.sportmonks.library.football.util.EventType;
+import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
@@ -447,5 +448,37 @@ class FixtureApiTest extends BaseApiTest {
 
         RateLimit byEntity = api.getRateLimitsByEntity().get("bookmaker");
         assertEquals(2999L, byEntity.getRemaining().longValue());
+
+        // The same readings are reachable from any specialised sub-API (shared tracker).
+        assertEquals(2999L, api.getOdds().getLastRateLimit().getRemaining().longValue());
+        assertEquals("bookmaker", api.getOdds().getRateLimitsByEntity().get("bookmaker").getRequestedEntity());
+    }
+
+    @Test
+    void rateLimitBody_absentLeavesBodyRateLimitEmpty() throws IOException, SportMonksException {
+        enqueue("fixtures_single_page.json"); // this fixture has no rate_limit block
+
+        api.getTodayMatches();
+
+        assertNull(api.getLastRateLimit());
+        assertTrue(api.getRateLimitsByEntity().isEmpty());
+    }
+
+    @Test
+    void rateLimitBody_emptyOrNullBodyIsIgnored() throws IOException, SportMonksException {
+        server.enqueue(jsonBody(""));      // empty body → skipped without parsing
+        api.getAllBookmakers();
+        assertNull(api.getLastRateLimit());
+
+        server.enqueue(jsonBody("null"));  // parses to no envelope → nothing recorded
+        api.getAllBookmakers();
+        assertNull(api.getLastRateLimit());
+    }
+
+    private MockResponse jsonBody(String body) {
+        return new MockResponse()
+                .setResponseCode(200)
+                .setBody(body)
+                .addHeader("Content-Type", "application/json; charset=utf-8");
     }
 }

--- a/src/test/java/es/com/kete1987/sportmonks/library/FixtureApiTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/FixtureApiTest.java
@@ -1,5 +1,6 @@
 package es.com.kete1987.sportmonks.library;
 
+import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
 import es.com.kete1987.sportmonks.library.common.util.SportMonksException;
 import es.com.kete1987.sportmonks.library.football.model.match.EventData;
 import es.com.kete1987.sportmonks.library.football.model.match.MatchDetail;
@@ -431,5 +432,20 @@ class FixtureApiTest extends BaseApiTest {
 
         assertEquals("3000", api.getMaximumRequests());
         assertEquals("2999", api.getRemainingRequests());
+    }
+
+    @Test
+    void rateLimitBody_isExposedPerEntityAfterRequest() throws IOException, SportMonksException {
+        enqueue("bookmakers.json");
+
+        api.getAllBookmakers();
+
+        RateLimit last = api.getLastRateLimit();
+        assertEquals(2999L, last.getRemaining().longValue());
+        assertEquals(3600L, last.getResetsInSeconds().longValue());
+        assertEquals("bookmaker", last.getRequestedEntity());
+
+        RateLimit byEntity = api.getRateLimitsByEntity().get("bookmaker");
+        assertEquals(2999L, byEntity.getRemaining().longValue());
     }
 }

--- a/src/test/java/es/com/kete1987/sportmonks/library/RateLimitTrackerTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/RateLimitTrackerTest.java
@@ -1,0 +1,73 @@
+package es.com.kete1987.sportmonks.library;
+
+import es.com.kete1987.sportmonks.library.common.model.ratelimit.RateLimit;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RateLimitTrackerTest {
+
+    private final RateLimitTracker tracker = new RateLimitTracker();
+
+    @Test
+    void startsEmpty() {
+        assertNull(tracker.last());
+        assertTrue(tracker.byEntity().isEmpty());
+    }
+
+    @Test
+    void tracksLastAndKeysByEntity() {
+        RateLimit league = rateLimit("league", 2999L);
+        RateLimit team = rateLimit("team", 2998L);
+
+        tracker.track(league);
+        tracker.track(team);
+
+        assertSame(team, tracker.last());
+        assertSame(league, tracker.byEntity().get("league"));
+        assertSame(team, tracker.byEntity().get("team"));
+    }
+
+    @Test
+    void ignoresNullReading() {
+        tracker.track(null);
+
+        assertNull(tracker.last());
+        assertTrue(tracker.byEntity().isEmpty());
+    }
+
+    @Test
+    void keepsLastButNotAnEntryWhenEntityIsAbsent() {
+        RateLimit noEntity = rateLimit(null, 100L);
+
+        tracker.track(noEntity);
+
+        assertSame(noEntity, tracker.last());
+        assertTrue(tracker.byEntity().isEmpty());
+    }
+
+    @Test
+    void byEntityIsAnImmutableSnapshot() {
+        tracker.track(rateLimit("league", 2999L));
+
+        Map<String, RateLimit> snapshot = tracker.byEntity();
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.put("team", rateLimit("team", 1L)));
+        // A later reading does not leak into the earlier snapshot.
+        tracker.track(rateLimit("team", 2998L));
+        assertEquals(1, snapshot.size());
+    }
+
+    private RateLimit rateLimit(String entity, Long remaining) {
+        RateLimit rateLimit = new RateLimit();
+        rateLimit.setRequestedEntity(entity);
+        rateLimit.setRemaining(remaining);
+        rateLimit.setResetsInSeconds(3600L);
+        return rateLimit;
+    }
+}

--- a/src/test/java/es/com/kete1987/sportmonks/library/RateLimitTrackerTest.java
+++ b/src/test/java/es/com/kete1987/sportmonks/library/RateLimitTrackerTest.java
@@ -55,9 +55,10 @@ class RateLimitTrackerTest {
     @Test
     void byEntityIsAnImmutableSnapshot() {
         tracker.track(rateLimit("league", 2999L));
-
         Map<String, RateLimit> snapshot = tracker.byEntity();
-        assertThrows(UnsupportedOperationException.class, () -> snapshot.put("team", rateLimit("team", 1L)));
+
+        RateLimit team = rateLimit("team", 1L);
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.put("team", team));
         // A later reading does not leak into the earlier snapshot.
         tracker.track(rateLimit("team", 2998L));
         assertEquals(1, snapshot.size());


### PR DESCRIPTION
## Qué

Expone el `rate_limit` que Sportmonks devuelve en el **body** de cada respuesta (scoped por `requested_entity`: `league`, `team`, …), que hasta ahora el facade descartaba. Lo único accesible era el header global `X-RateLimit-*` (última llamada, no por entidad).

## Cómo

- `SportMonksApiBase.execute()` parsea el bloque `rate_limit` de forma central y best-effort (nunca hace fallar una petición), cubriendo **todos** los endpoints presentes y futuros.
- `RateLimitTracker` acumula el último `RateLimit` y un mapa por entidad (thread-safe).
- Nuevos getters en la base y en el facade `SportMonksAPI`:
  - `RateLimit getLastRateLimit()` — el `rate_limit` de la última llamada.
  - `Map<String, RateLimit> getRateLimitsByEntity()` — snapshot inmutable por `requested_entity`.
- README actualizado.

## Tests

- Nuevo `FixtureApiTest#rateLimitBody_isExposedPerEntityAfterRequest`.
- Suite completa verde: **298 tests**.

Habilita la tarea de la app [86cabmr6t](https://app.clickup.com/t/86cabmr6t) (mostrar peticiones restantes por entidad/método).

🤖 Generated with [Claude Code](https://claude.com/claude-code)